### PR TITLE
HIP/ROCm: two crash fixes for TurboQuant KV cache on RDNA    

### DIFF
--- a/ggml/src/ggml-cuda/fattn-tile.cuh
+++ b/ggml/src/ggml-cuda/fattn-tile.cuh
@@ -68,6 +68,7 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_nv
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256, 2,  64,  64)
 
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64, 2,  32,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256, 2,  64,  64)
@@ -132,6 +133,7 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_nv
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256, 2,  32, 128)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256, 2,  32,  64)
 
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64, 2,  32,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128, 2,  32,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256, 2,  32,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256, 2,  32,  64)
@@ -203,6 +205,7 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_am
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256, 2,  32, 128)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256, 2,  32, 128)
 
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64, 2,  32,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256, 2,  64,  64)
@@ -277,6 +280,7 @@ static constexpr __host__ __device__ uint32_t ggml_cuda_fattn_tile_get_config_am
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 16, 256, 5,  32, 256)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(256, 256, 32, 256, 3,  64, 128)
 
+    GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  2,  64, 2,  32,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  4, 128, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512,  8, 256, 2,  64,  64)
     GGML_CUDA_FATTN_TILE_CONFIG_CASE(512, 512, 16, 256, 4,  64,  64)
@@ -1259,6 +1263,16 @@ static void launch_fattn_tile_switch_ncols2(ggml_backend_cuda_context & ctx, ggm
             launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap>(ctx, dst);
             return;
         }
+
+        // DV > 256 (e.g. DKQ=DV=512, head_dim=512 models): extend GQA fallback to ncols2=2/1.
+        // Without this, gqa_ratio not divisible by 4 (e.g. ratio=2) reaches GGML_ABORT.
+        if (use_gqa_opt && gqa_ratio % 2 == 0) {
+            launch_fattn_tile_switch_ncols1<DKQ, DV, 2, use_logit_softcap>(ctx, dst);
+            return;
+        }
+
+        launch_fattn_tile_switch_ncols1<DKQ, DV, 1, use_logit_softcap>(ctx, dst);
+        return;
     }
     GGML_ABORT("fatal error");
 }

--- a/ggml/src/ggml-hip/CMakeLists.txt
+++ b/ggml/src/ggml-hip/CMakeLists.txt
@@ -85,14 +85,17 @@ else()
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-turbo3_0.cu
+        ../ggml-cuda/template-instances/fattn-vec-instance-f16-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo2_0-turbo2_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo2_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-turbo2_0.cu
+        ../ggml-cuda/template-instances/fattn-vec-instance-f16-turbo2_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-turbo2_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo2_0-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-turbo4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-q8_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-q8_0-turbo4_0.cu
+        ../ggml-cuda/template-instances/fattn-vec-instance-f16-turbo4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-turbo3_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo3_0-turbo4_0.cu
         ../ggml-cuda/template-instances/fattn-vec-instance-turbo4_0-turbo2_0.cu


### PR DESCRIPTION
## Overview

This PR fixes a linking problem and a runtime crash when using mtp models like Gemma 4 assistant.                                                                                                                                                                                                                                                      

Tested on a Ryzen AI HX 470 (gfx1150, RDNA3.5) running Gemma 4 E4B with:        
                                                                                                        
```bash
./build/bin/llama-server \
    -m         ./models/gemma-4-E4B-it-Q4_K_M.gguf \
    --mtp-head ./models/gemma-4-E4B-it-assistant.Q4_K_M.gguf \
    --spec-type mtp \
    --draft-block-size 3 --draft-max 8 --draft-min 0 \
    -ngl 99 -ngld 99 \
    -ctk turbo3 -ctv turbo3 -ctkd turbo3 -ctvd turbo3 \
    -fa on -c 16384 --host 127.0.0.1 --port 8080
```                                                                                                          
                                                                                                                                                
OS : Linux Mint 22.3 (based on Ubuntu 20.04.04) with ROCm 7.2.1 installed
                                                               
### Fix 1 — HIP linker error: missing fattn-vec template instances                                                                                                                        

`ggml/src/ggml-hip/CMakeLists.txt` was missing three cross-type flash-attention VEC instances (f16 key × turbo2/3/4 value) that were already present in `ggml/src/ggml-cuda/CMakeLists.txt`.

This produced link errors at the final llama-server link step:                                                                                     
  
```                                                                                                                                                                                      
  undefined reference to void ggml_cuda_flash_attn_ext_vec_case<                                                                                                                        
      256, (ggml_type)1, (ggml_type)42>                                                                                                                                                 
  undefined reference to void ggml_cuda_flash_attn_ext_vec_case<                                                                                                                        
      256, (ggml_type)1, (ggml_type)43>                                                                                                                                                 
  undefined reference to void ggml_cuda_flash_attn_ext_vec_case<                                                                                                                        
      256, (ggml_type)1, (ggml_type)44>                                                                                                                                                 
  ```                                                                                                                                                                                      
 
 Fix: added the three files to the HIP CMake list.                                                                                                                                     
                                                                                                                                                                                        
###  Fix 2 — Runtime GGML_ABORT in fattn-tile.cuh for head_dim=512                                                                                                                         

Gemma 4 E4B has head_dim = 4096 / 8 = 512. For head_dim=512, all fast FA paths are excluded on AMD:                                                                                   
 - VEC — capped at head_dim ≤ 256
 - WMMA — explicitly excludes Q->ne[0] == 512                                                                                                                                          
 - MFMA — explicitly excludes Q->ne[0] == 512
                                                                                                                                                                                        
  So TILE is always selected. Inside `launch_fattn_tile_switch_ncols2<512, 512>`, the `DKQ ≤ 512` block only handled `gqa_ratio % 4 == 0` and `gqa_ratio % 8 == 0`, then a `DV ≤ 256` guard for smaller ratios. For DV=512 with gqa_ratio=2 (Gemma 4: 8 Q-heads / 4 KV-heads) the code fell straight through to GGML_ABORT("fatal error").                                            
Fix:                                                                                                                                                                                  
  1. Dispatch — added ncols2=2 (for gqa_ratio % 2 == 0) and ncols2=1 (unconditional fallback) inside the DKQ ≤ 512 block after the DV ≤ 256 guard, mirroring the pattern that already exists for DV ≤ 256.                                                                                                                                                                  
  2. Kernel configs — added (512, 512, ncols=2, nthreads=64, occupancy=2, nbatch_fa=32, nbatch_K=64) to all four config tables (nvidia_fp16, nvidia_fp32, amd, amd_rdna). Without these entries the device-side static_assert inside flash_attn_tile<512,512,1,2> would fire at compile time.

### What fix this PR 

Before fix 1: linker error, binary not produced.                                                                                                                                      
Before fix 2: crash during first decode step with fattn-tile.cuh:1263: fatal error.
After both fixes: server runs without crash, MTP speculative decoding functional.                                                                      

## Test procedure
                                                                                                                                                                                        
### Build         

```bash
cmake -B build -DGGML_HIP=ON -DAMDGPU_TARGETS=gfx1150 -DCMAKE_BUILD_TYPE=Release                                                                                                      
cmake --build build --target llama-server -j$(nproc)                                                                                                                                  ```

### Start server

```bash                                                                                                                                                     
./build/bin/llama-server \
    -m         ./models/gemma-4-E4B-it-Q4_K_M.gguf \
    --mtp-head ./models/gemma-4-E4B-it-assistant.Q4_K_M.gguf \
    --spec-type mtp \
    --draft-block-size 3 --draft-max 8 --draft-min 0 \
    -ngl 99 -ngld 99 \
    -ctk turbo3 -ctv turbo3 -ctkd turbo3 -ctvd turbo3 \
    -fa on -c 16384 --host 127.0.0.1 --port 8080
```
                                                                                                                                                           
### Benchmark

Here is a table with all tests result made.
Details of the command use to launch the server : 
**Baseline - Standard llama.cpp from [llamacpp-rocm](https://github.com/lemonade-sdk/llamacpp-rocm)** : `./llama-server -m ../atomic-llama-cpp-turboquant/models/gemma-4-E4B-it-Q4_K_M.gguf -ngl 99 -ngld 99   -fa on -c 16384 --host 127.0.0.1 --port 8080`
**KV Cache + MTP-HEAD** : `./build/bin/llama-server -m ./models/gemma-4-E4B-it-Q4_K_M.gguf --mtp-head ./models/gemma-4-E4B-it-assistant.Q4_K_M.gguf --spec-type mtp --draft-block-size 3 --draft-max 8 --draft-min 0     -ngl 99 -ngld 99     -ctk turbo3 -ctvd turbo3 -fa on -c 16384 --host 127.0.0.1 --port 8080
`
**MTP-HEAD Only** : `./build/bin/llama-server -m ./models/gemma-4-E4B-it-Q4_K_M.gguf --mtp-head ./models/gemma-4-E4B-it-assistant.Q4_K_M.gguf --spec-type mtp --draft-block-size 3 --draft-max 8 --draft-min 0 -ngl 99 -ngld 99  -fa on -c 16384 --host 127.0.0.1 --port 8080;`
**KV Cache Only** : `./build/bin/llama-server -m ./models/gemma-4-E4B-it-Q4_K_M.gguf  -ngl 99 -ngld 99 -ctk turbo3 -ctvd turbo3 -fa on -c 16384 --host 127.0.0.1 --port 8080;`


All test are runs with : 
```bash
PORT=8080 PARALLEL=1 N_PREDICT=200 ./scripts/bench-parallel.sh
PORT=8080 PARALLEL=4 N_PREDICT=200 ./scripts/bench-parallel.sh
```

| Type | PARALLEL=1 (per_seq_tps)| Speed (compare to baseline) | PARALLEL=4 (per_seq_tps) | Speed (compare to baseline) |
| ----------- | ----------- | ----------- | ----------- |----------- |
| Baseline | 25.15 | x1.0 | 14.10 | x1.0|
| KV Cache + MTP Head | 30.84 | x1.22 | 18.96 |  **x1.34**|
| MTP Head Only| 32.51 | **x1.29** | 18.52 | x1.31|
| KV Cache Only | 23.69 | x0.94 | 13.03 | x0.92|


# Requirements

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: YES, to be honest the dev has entirely be done by Claude Code, I never worked on llama.cpp code, just wanted to run gemma with mtp assistant on my machine. If this doesn't match llama.cpp requirement then at least the code will be somewhere public.
