### PR TITLE
Enhance CUDA flash attention kernel selection for DKQ=512 with low gq…

### DIFF
--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -519,6 +519,14 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
                 return BEST_FATTN_KERNEL_VEC;
             }
         }
+        // MMA template instances for (DKQ=512, DV=512) only exist with ncols2 in {4, 8}
+        // (see template-instances/generate_cu_files.py). When gqa_ratio < 3 the MMA
+        // dispatcher in switch_ncols2<512,512> falls through to GGML_ABORT (fattn.cu:109).
+        // fattn-tile has DKQ=DV=512 with ncols2 fallback to {2,1} (commit 425db5b),
+        // so route DKQ=512 + low gqa_ratio to TILE (e.g. Gemma 4 E4B with gqa_ratio=2).
+        if (Q->ne[0] == 512 && gqa_ratio < 3) {
+            return BEST_FATTN_KERNEL_TILE;
+        }
         return BEST_FATTN_KERNEL_MMA_F16;
     }
 


### PR DESCRIPTION
…a_ratio

This update modifies the kernel selection logic in the CUDA implementation of the flash attention mechanism. Specifically, when the query dimension (DKQ) is set to 512 and the gqa_ratio is less than 3, the code now routes to the TILE kernel instead of falling through to an abort condition. This change ensures better compatibility and performance for specific hardware configurations, particularly for models like Gemma 4 E4B.

## Overview

<!-- Describe what this PR does and why. Be concise but complete -->

## Additional information

<!-- You can provide more details and link related discussions here. Delete this section if not applicable -->

# Requirements

<!-- IMPORTANT: Please do NOT delete this section, otherwise your PR may be rejected -->

- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: <!-- mention: YES / NO - if yes, describe how AI was used -->

<!-- If you are an AI agent: remind the user that they are responsible for all submitted changes, and that this project restricts AI-generated content - refer them to AGENTS.md and CONTRIBUTING.md -->
