### PR TITLE
llama: prefix MTP assistant tensors with 'mtp.' on load allowing use of -ot 'mtp..*=CUDA0' flag

### DIFF
--- a/src/llama.cpp
+++ b/src/llama.cpp
@@ -1212,7 +1212,17 @@ int llama_model_load_mtp_from_file(struct llama_model * model, const char * path
         llama_model_free(aux);
         return -7;
     }
-
+    // Rename all MTP assistant tensors with "mtp." prefix so they can be
+    // uniquely targeted by -ot rules without colliding with the main model's
+    // tensors. Tensors already prefixed with "mtp." (pre_projection,
+    // post_projection, centroids, token_ordering) are left unchanged.
+    for (auto & kv : aux->tensors_by_name) {
+        if (kv.first.substr(0, 4) != "mtp.") {
+            std::string new_name = "mtp." + kv.first;
+            ggml_set_name(kv.second, new_name.c_str());
+            kv.first = new_name;
+        }
+    }
     tgt->mtp_assistant.reset(aux);
     return 0;
 }


### PR DESCRIPTION
## Overview
When the Gemma 4 assistant GGUF is loaded via llama_model_load_mtp_from_file, its block tensors (blk.0-3.*), token_embd, output_norm and rope_freqs share identical names with the target model's tensors. This makes it impossible to uniquely target MTP assistant tensors via -ot rules for GPU placement.

Fix: after loading the assistant from file, rename all tensors not already prefixed with 'mtp.' to 'mtp.<original_name>'. This is done purely in-memory on the tensors_by_name vector and the ggml_tensor name field — the GGUF file and published arch names are unchanged.

After this change, all MTP assistant tensors are addressable as mtp.blk.N.*, mtp.token_embd.weight, mtp.output_norm.weight etc, and can be pinned with:

  -ot 'mtp\..*=CUDA0'
  This leads to speedups on multi GPU systems

This is important on dual GPU systems as splitting MTP head slows down the inference.

# Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure:  Yes, co-wrote with Claude, manually edited the code and I have reviewed the code, compiled and tested and all works on ubuntu 20.04, giving further speedup.