### PR TITLE
fix: add missing prototype for turbo_cpu_fwht_inverse to resolve -Wmissing-prototypes CI error

### DIFF
--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -16,6 +16,8 @@
 #include <assert.h>
 #include <stdlib.h>
 
+GGML_API void turbo_cpu_fwht_inverse(float * x, int group_size);
+
 #ifndef M_PI
 #define M_PI 3.14159265358979323846
 #endif


### PR DESCRIPTION
## Overview
turbo_cpu_fwht_inverse was added in 07595065d without a forward declaration, triggering -Wmissing-prototypes which is treated as -Werror in the expanded CI suite, causing all builds to fail.
 Fix: add forward declaration before the function definition in ggml-turbo-quant.c.
 
## Additional information
Referenced in https://github.com/AtomicBot-ai/atomic-llama-cpp-turboquant/pull/8

# Requirements
- I have read and agree with the [contributing guidelines](https://github.com/ggml-org/llama.cpp/blob/master/CONTRIBUTING.md)
- AI usage disclosure: Yes, cowrote with Claude, reran build locally and now compiling without warnings on ubuntu 20.04
