### PR TITLE
ggml: ARM NEON dequant kernel for turbo4 (vqtbl4q_u8 4-bit PolarQuant)

### DIFF
--- a/ggml/src/ggml-turbo-quant.c
+++ b/ggml/src/ggml-turbo-quant.c
@@ -565,6 +565,73 @@ void quantize_row_turbo4_0_ref(const float * GGML_RESTRICT x, block_turbo4_0 * G
     }
 }
 
+/* ---------- Optional ARM NEON dequant for TURBO4 (4-bit PolarQuant) ----------
+ * Enabled by default on aarch64 with NEON (ARMv8.0+). Bit-exact with the scalar
+ * implementation: pre-scales the 16-entry CENTROIDS_4BIT * norm into a 64-byte
+ * LUT held in 4x uint8x16_t, then uses vqtbl4q_u8 for SIMD nibble->fp32 lookup.
+ * Measured ~2x speedup on Cortex-A76 microbench, ~2-3% end-to-end tok/s on Pi16.
+ * Disable with -DGGML_TURBO_NEON_DISABLE if needed for debug or A/B.
+ */
+#if defined(__ARM_NEON) && defined(__aarch64__) && !defined(GGML_TURBO_NEON_DISABLE)
+#define GGML_TURBO_NEON 1
+#include <arm_neon.h>
+
+static const uint8_t turbo4_neon_bc_lo[16]  = { 0,0,0,0, 1,1,1,1, 2,2,2,2, 3,3,3,3 };
+static const uint8_t turbo4_neon_bc_hi[16]  = { 4,4,4,4, 5,5,5,5, 6,6,6,6, 7,7,7,7 };
+static const uint8_t turbo4_neon_stride[16] = { 0,1,2,3, 0,1,2,3, 0,1,2,3, 0,1,2,3 };
+
+static inline void dequantize_row_turbo4_0_neon_4bit(
+        const block_turbo4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int nb,
+        const float * GGML_RESTRICT centroids_4bit) {
+    const uint8x16_t bc_lo   = vld1q_u8(turbo4_neon_bc_lo);
+    const uint8x16_t bc_hi   = vld1q_u8(turbo4_neon_bc_hi);
+    const uint8x16_t stride  = vld1q_u8(turbo4_neon_stride);
+    const uint8x8_t  mask_lo = vdup_n_u8(0x0F);
+
+    const float32x4_t lut_raw0 = vld1q_f32(centroids_4bit + 0);
+    const float32x4_t lut_raw1 = vld1q_f32(centroids_4bit + 4);
+    const float32x4_t lut_raw2 = vld1q_f32(centroids_4bit + 8);
+    const float32x4_t lut_raw3 = vld1q_f32(centroids_4bit + 12);
+
+    for (int block = 0; block < nb; block++) {
+        const float norm = GGML_FP16_TO_FP32(x[block].norm);
+        const float32x4_t vnorm = vdupq_n_f32(norm);
+
+        const uint8x16x4_t lut = {{
+            vreinterpretq_u8_f32(vmulq_f32(lut_raw0, vnorm)),
+            vreinterpretq_u8_f32(vmulq_f32(lut_raw1, vnorm)),
+            vreinterpretq_u8_f32(vmulq_f32(lut_raw2, vnorm)),
+            vreinterpretq_u8_f32(vmulq_f32(lut_raw3, vnorm)),
+        }};
+
+        float * dst = y + block * QK_TURBO4;
+        const uint8_t * qs = x[block].qs;
+
+        for (int i = 0; i < QK_TURBO4; i += 8) {
+            uint32_t packed_raw;
+            memcpy(&packed_raw, qs + i / 2, 4);
+            uint8x8_t packed = vreinterpret_u8_u32(vdup_n_u32(packed_raw));
+
+            uint8x8_t lo = vand_u8(packed, mask_lo);
+            uint8x8_t hi = vshr_n_u8(packed, 4);
+            uint8x8x2_t zipped = vzip_u8(lo, hi);
+            uint8x8_t nibbles = zipped.val[0];
+            uint8x8_t nib_x4 = vshl_n_u8(nibbles, 2);
+            uint8x16_t nib_x4_q = vcombine_u8(nib_x4, vdup_n_u8(0));
+
+            uint8x16_t tbl_idx_lo = vaddq_u8(vqtbl1q_u8(nib_x4_q, bc_lo), stride);
+            uint8x16_t tbl_idx_hi = vaddq_u8(vqtbl1q_u8(nib_x4_q, bc_hi), stride);
+
+            uint8x16_t out_lo = vqtbl4q_u8(lut, tbl_idx_lo);
+            uint8x16_t out_hi = vqtbl4q_u8(lut, tbl_idx_hi);
+
+            vst1q_u8((uint8_t *)(dst + i + 0), out_lo);
+            vst1q_u8((uint8_t *)(dst + i + 4), out_hi);
+        }
+    }
+}
+#endif /* aarch64 NEON */
+
 void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGML_RESTRICT y, int64_t k) {
     turbo_init_rotation();
 
@@ -573,14 +640,17 @@ void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGM
     const int d  = QK_TURBO4;
 
 #if TURBO4_USE_4BIT
-    /* 4-bit PolarQuant: nibble unpack → centroid → inverse rotate → scale */
-    /* TODO: add proper 4-bit centroid table to C code (currently only in Metal) */
+    /* 4-bit PolarQuant: nibble unpack -> centroid * norm (no inverse WHT, stays in rotated domain). */
     static const float CENTROIDS_4BIT[16] = {
         -0.173926f, -0.117195f, -0.089527f, -0.068756f,
         -0.051262f, -0.035597f, -0.020989f, -0.006938f,
          0.006938f,  0.020989f,  0.035597f,  0.051262f,
          0.068756f,  0.089527f,  0.117195f,  0.173926f
     };
+#ifdef GGML_TURBO_NEON
+    dequantize_row_turbo4_0_neon_4bit(x, y, nb, CENTROIDS_4BIT);
+    (void)d;
+#else
     for (int block = 0; block < nb; block++) {
         float norm = GGML_FP16_TO_FP32(x[block].norm);
         float * dst = y + block * d;
@@ -589,10 +659,10 @@ void dequantize_row_turbo4_0(const block_turbo4_0 * GGML_RESTRICT x, float * GGM
             dst[i] = CENTROIDS_4BIT[idx] * norm;
         }
         /* No inverse WHT, dequant stays in the rotated domain.
-        * Q is WHT-rotated by the graph, so <Q_rot, K_rot> gives correct attention scores.
-        * The inverse WHT is applied to the attention output via GGML_OP_TURBO_WHT (direction=1) in the graph. 
-        */
+         * Q is WHT-rotated by the graph; the inverse WHT is applied to attention output via GGML_OP_TURBO_WHT.
+         */
     }
+#endif /* GGML_TURBO_NEON */
 #else
     /* Legacy 3-bit + QJL dequant */
     turbo_init_qjl();


### PR DESCRIPTION
## Summary

First aarch64 NEON SIMD implementation of the TurboQuant turbo4_0 dequantization kernel. Reference impls already cover Metal (Apple Silicon), CUDA (NVIDIA), Vulkan (cross-GPU) and a portable scalar C path. This adds the ARM NEON path, which is the dominant SIMD on edge devices: Raspberry Pi 4/5, Apple M-series, AWS Graviton, Cortex-X Android.

## Algorithm

For each block (`QK_TURBO4 = 128` elements):

1. Load `norm` fp16 → fp32, broadcast to a `float32x4_t`.
2. Multiply the 16-entry `CENTROIDS_4BIT` table by `norm` → 16 pre-scaled fp32 values (64 bytes) held in 4× `uint8x16_t` (= `uint8x16x4_t`).
3. Per inner iteration (16 iters per block, 8 elements each):
   - Load 4 packed bytes (8 nibbles) from `qs`.
   - Extract low/high nibbles via `vand_u8` + `vshr_n_u8`, interleave via `vzip_u8`.
   - Multiply nibbles by 4 (= LUT byte offset) via `vshl_n_u8`.
   - Build full 16-byte index vector by broadcasting nibbles via `vqtbl1q_u8` against `{0,0,0,0,1,1,1,1,…}` and adding `{0,1,2,3,…}` stride.
   - Apply `vqtbl4q_u8(lut, idx)` — SIMD lookup into the 64-byte pre-scaled LUT.
   - Store as two `float32x4_t` per iteration.

Total per block: ~36 vector ops vs ~768 scalar ops (load + shift + mask + scalar gather + scalar mul + store × 128 elements).

## Bit-exact guarantee

Pre-scaling the LUT (`centroid * norm` once per LUT entry) instead of per element (`centroid * norm` per dequant) produces the same fp32 product. IEEE 754 fp32 multiplication is deterministic; the multiplication operands are bit-identical between scalar and NEON paths. `vqtbl4q_u8` is a pure byte permutation (no arithmetic) so the lookup itself is also bit-preserving.

A standalone validator (`neon-turbo4-poc/validate.c`) confirms this empirically:

> N = **10,000** random blocks × **128** elements = **1,280,000** fp32 values, **0** bit-mismatches vs scalar reference.

Build: `gcc -O3 -march=armv8.2-a+fp16 -ffp-contract=off` (FMA contraction disabled to prevent compiler-introduced precision divergence between paths).

## Performance

### Microbench (standalone kernel, Cortex-A76 / Raspberry Pi 16 GB)

| Working set | Scalar ns/block | NEON ns/block | Scalar GB/s out | NEON GB/s out | Speedup |
|---|---|---|---|---|---|
| 128 blocks (8.7 KB) | 171.37 | 80.17 | 2.99 | 6.39 | **2.14×** |
| 512 blocks (35 KB) | 164.21 | 83.23 | 3.12 | 6.15 | 1.97× |
| 2048 blocks (140 KB) | 163.76 | 80.87 | 3.13 | 6.33 | 2.03× |
| 4096 blocks (280 KB) | 161.97 | 80.92 | 3.16 | 6.33 | 2.00× |
| 16384 blocks (1.1 MB) | 161.38 | 82.00 | 3.17 | 6.24 | 1.97× |
| 65536 blocks (4.4 MB) | 160.80 | 84.88 | 3.18 | 6.03 | 1.89× |

Robust **1.89-2.14× speedup** across L1/L2/DRAM working sets. NEON path is memory-bound near 6 GB/s output bandwidth (Cortex-A76 LPDDR4X-4267 single-thread ceiling). 2× rather than 5-10× because gcc `-O3` auto-vectorizes partial scalar arithmetic but cannot vectorize the 16-entry fp32 LUT gather across nibble indices.

### End-to-end llama-server (Gemma E4B + turbo4 KV cache)

| Prompt | Tokens | Scalar AVG | NEON AVG | Δ |
|---|---|---|---|---|
| long_200 (attention paragraph, 200 max) | 126 generated | 2.10 tok/s | 2.17 tok/s | **+3.3%** |
| med_150 (Bayesian 5 properties, 150 max) | 69 generated | 2.14 tok/s | 2.18 tok/s | +1.9% |

CV ~2-3% per cell, 3 trials each, temperature=0, cache_prompt=false. Modest end-to-end gain is expected — dequant is a small fraction of total inference cost, so per Amdahl 2× on ~5% fraction ≈ ~2.5% wall-clock.

## Verification on the binary

The kernel inlines into `dequantize_row_turbo4_0`. `objdump -d build/bin/libggml-base.so` confirms expected instructions:

```
4f9f90db    fmul    v27.4s, v6.4s, v31.s[0]       ; LUT × norm pre-scale (×4)
4e0103da    tbl     v26.16b, {v30.16b}, v1.16b    ; vqtbl1q_u8 broadcast
4e1a629a    tbl     v26.16b, {v20.16b-v23.16b}, v26.16b   ; vqtbl4q_u8 64-byte LUT lookup
```

## Build dispatch

- **Default on aarch64 + NEON** : NEON path active via `#if defined(__ARM_NEON) && defined(__aarch64__) && !defined(GGML_TURBO_NEON_DISABLE)`. Sets `#define GGML_TURBO_NEON 1`.
- **Other targets** (x86, RISC-V, scalar-only ARM): scalar fallback unchanged, no behavior change.
- **Explicit disable for debug or A/B**: `-DGGML_TURBO_NEON_DISABLE` (used in the end-to-end measurements above).
- **No CMake change** — compile-time autodetection via `__ARM_NEON` + `__aarch64__` predefined macros.

## Limitations / follow-ups (not in this PR)

- Only `turbo4_0` 4-bit PolarQuant branch (`TURBO4_USE_4BIT=1`, the default) is NEON-accelerated. `turbo3_0` (3-bit, 8 centroids) and `turbo2_0` (2-bit, 4 centroids) paths still fall through to scalar. Both are analogous, would be follow-up PRs.
- `quantize_row_turbo4_0_ref` (encode path) unchanged; called only at model load + KV-cache-write, not on the inference hot path.
- `turbo_cpu_fwht` (128-element Walsh-Hadamard butterfly) still scalar. NEON-izing would require a 7-stage `vtrn`/`vrev` butterfly; separate scope.

## Test plan

- [x] Bit-exact: 10,000 random blocks, 0 mismatches vs scalar.
- [x] Microbench: 1.89-2.14× speedup across L1/L2/DRAM working sets.
- [x] End-to-end: llama-server tok/s improvement empirically observed.
- [x] Disassembly: vqtbl4q_u8 + fmul confirmed in compiled binary.
- [x] Zero-cost fallback on non-aarch64: scalar code path unchanged behind `#else`.
