### PR TITLE
Gemma-4 MTP: skip pooling/sampling epilogue for MTP graphs (fixes decode crash) + widen DKQ=512 TILE routing to all gqa_ratio

### DIFF
--- a/convert_hf_to_gguf.py
+++ b/convert_hf_to_gguf.py
@@ -7817,7 +7817,7 @@ class Gemma4Model(Gemma3Model):
         yield from super().modify_tensors(data_torch, name, bid)
 
 
-@ModelBase.register("Gemma4AssistantForCausalLM")
+@ModelBase.register("Gemma4AssistantForCausalLM", "Gemma4UnifiedAssistantForCausalLM")
 class Gemma4AssistantModel(Gemma4Model):
     model_arch = gguf.MODEL_ARCH.GEMMA4_ASSISTANT
 

--- a/ggml/src/ggml-cuda/fattn.cu
+++ b/ggml/src/ggml-cuda/fattn.cu
@@ -409,10 +409,12 @@ static best_fattn_kernel ggml_cuda_get_best_fattn_kernel(const int device, const
             if (V->ne[0] != K->ne[0]) {
                 return BEST_FATTN_KERNEL_NONE;
             }
-            if (!gqa_opt_applies) {
-                return BEST_FATTN_KERNEL_NONE;
-            }
-            break;
+            // MMA template instances for DKQ=512 only exist for ncols2 in {4,8},
+            // requiring gqa_ratio < 3. Gemma-4 (12B/26B/31B) has gqa_ratio=8 and
+            // aborts in switch_ncols2<512,512>. fattn-tile supports DKQ=512 with
+            // ncols2 fallback to {2,1}. Route ALL DKQ=512 cases to TILE here so
+            // the early-return path and the no-mask MTP cross-attn path are both covered.
+            return BEST_FATTN_KERNEL_TILE;
         case 576:
         case 640:
             if (V->ne[0] != 512) {

--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1105,10 +1105,14 @@ void llama_context::set_abort_callback(bool (*abort_callback)(void * data), void
 void llama_context::set_embeddings(bool value) {
     LLAMA_LOG_DEBUG("%s: value = %d\n", __func__, value);
 
+    const bool changed = (cparams.embeddings != value);
     cparams.embeddings = value;
-
-    // TODO: not sure yet if we want to reserve here
-    //sched_need_reserve = true;
+    // Changing embeddings mode changes the graph topology (adds/removes the backbone
+    // hidden-state output node). Re-reserve so compute buffers are sized correctly.
+    // Only trigger re-reserve on actual change — not on redundant same-value calls.
+    if (changed) {
+        sched_need_reserve = true;
+    }
 }
 
 void llama_context::set_embeddings_pre_norm(bool value) {
@@ -2691,6 +2695,11 @@ int32_t llama_context::decode_mtp_async(
         LLAMA_LOG_ERROR("%s: failed to initialize MTP scheduler\n", __func__);
         return -8;
     }
+
+    // Flush main scheduler so KV cache writes from the preceding llama_decode are
+    // visible to the MTP worker's CUDA reads before it starts. Without this sync
+    // the worker races the still-in-flight CUDA async writes and reads stale K/V.
+    ggml_backend_sched_synchronize(sched.get());
 
     {
         std::unique_lock<std::mutex> lk(mtp_mu);

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -79,7 +79,13 @@ void llm_graph_input_embd::set_input(const llama_ubatch * ubatch) {
         ggml_backend_tensor_set(tokens, ubatch->token, 0, n_tokens*ggml_element_size(tokens));
     }
 
-    if (ubatch->embd) {
+    // Guard on `embd` being non-null (mirrors the can_reuse() check below): gemma4's
+    // per-layer-token input reuses this same input class but only allocates `tokens`
+    // (never `embd`). When the batch carries raw embeddings (ubatch->embd != null) --
+    // e.g. the Gemma-4 MTP / embeddings verify path -- that per-layer input would
+    // otherwise dereference a null `embd` here. Only the input that actually built an
+    // `embd` tensor should consume ubatch->embd.
+    if (ubatch->embd && embd) {
         GGML_ASSERT(n_embd == embd->ne[0]);
 
         const int64_t n_tokens = ubatch->n_tokens;

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -1650,6 +1650,13 @@ void llama_model::load_hparams(llama_model_loader & ml) {
                 hparams.n_layer_kv_from_start = hparams.n_layer - (int32_t) n_kv_shared_layers;
                 hparams.f_attention_scale     = 1.0f;
 
+                if (hparams.n_layer > 0 && hparams.n_layer_kv_from_start <= 0) {
+                    LLAMA_LOG_WARN("%s: gemma4_assistant KV sharing metadata leaves no dedicated KV layers "
+                                   "(n_layer=%u, shared_kv_layers=%u); disabling reuse\n",
+                            __func__, hparams.n_layer, n_kv_shared_layers);
+                    hparams.n_layer_kv_from_start = (int32_t) hparams.n_layer;
+                }
+
                 ml.get_key(LLM_KV_ROPE_FREQ_BASE_SWA,          hparams.rope_freq_base_train_swa, false);
                 ml.get_key(LLM_KV_ATTENTION_SLIDING_WINDOW,    hparams.n_swa);
                 ml.get_key(LLM_KV_ATTENTION_LAYERNORM_RMS_EPS, hparams.f_norm_rms_eps);

--- a/src/llama-model.cpp
+++ b/src/llama-model.cpp
@@ -9580,11 +9580,21 @@ ggml_cgraph * llama_model::build_graph(const llm_graph_params & params) const {
             GGML_ABORT("fatal error");
     }
 
-    // add on pooling layer
-    llm->build_pooling(cls, cls_b, cls_out, cls_out_b, cls_norm);
+    // The Gemma-4 MTP graph is self-contained: it produces its own logits / h_post /
+    // on-device argmax and is driven on a dedicated scheduler. The shared embedding
+    // pooling and backend-sampling epilogues are for the main decode path only. They
+    // must be skipped for MTP graphs: the speculative path forces cparams.embeddings=true
+    // (so the main decode emits backbone hidden states), and that flag would otherwise
+    // make build_pooling run against the MTP graph's t_embd (h_post) -- which has no
+    // pooling inputs and crashes -- and build_sampling attach backend samplers to the
+    // MTP logits, which MTP never consumes.
+    if (params.gtype != LLM_GRAPH_TYPE_MTP) {
+        // add on pooling layer
+        llm->build_pooling(cls, cls_b, cls_out, cls_out_b, cls_norm);
 
-    // add backend sampling layers (if any)
-    llm->build_sampling();
+        // add backend sampling layers (if any)
+        llm->build_sampling();
+    }
 
     // if the gguf model was converted with --sentence-transformers-dense-modules
     // there will be two additional dense projection layers


### PR DESCRIPTION
## Summary

Gemma-4 MTP speculative decode crashed with a silent access violation (Windows `0xC0000005`) on the first draft step, for both E4B and 12B targets. This PR fixes the crash and makes MTP speculative decode work end-to-end.

The crash was traced by binary-searching the decode path with flushed log probes on an E4B repro (E4B has `gqa_ratio=2`, so it clears the fattn DKQ=512 abort and reaches the *real* bug; the 12B's DKQ=512 abort masks it). Instrumentation proved the verify batch's `set_inputs` **and** `graph_compute` both complete with status 0 and `decode()` returns 0 — the crash is later, in MTP graph construction.

## Root cause

The MTP speculative path calls `llama_set_embeddings(ctx, true)` so the main decode emits backbone hidden states for the drafter, and that flag stays set. `llama_model::build_graph()` runs a shared `build_pooling()` + `build_sampling()` epilogue on **every** graph. `build_pooling()` early-returns only `if (!cparams.embeddings)`. With embeddings forced true, it runs against the **MTP graph's** `t_embd` (= `h_post`, the backbone projection — which has no pooling inputs) and dereferences bad memory.

A second latent bug rode along: `build_sampling()` would attach backend samplers to the MTP logits, which MTP never consumes (it does its own on-device argmax).

## Fix

- **`src/llama-model.cpp`** — gate the shared epilogue: `if (params.gtype != LLM_GRAPH_TYPE_MTP) { build_pooling(...); build_sampling(); }`. The MTP graph is self-contained and must not receive the main-decode pooling/sampling layers. **This is the actual unblock.**
- **`ggml/src/ggml-cuda/fattn.cu`** — route **all** `DKQ=512` cases to the TILE kernel. This **generalizes the existing `fix/cuda-mma-dkq512-fallback` branch**, whose `gqa_ratio < 3` guard only covers E4B (`gqa_ratio=2`). Gemma-4 12B/26B/31B have `gqa_ratio=8`, fail that guard, and still hit the MMA `GGML_ABORT`. Routing all DKQ=512 to TILE covers them and the no-mask MTP cross-attention path. (Happy to rebase this onto `fix/cuda-mma-dkq512-fallback` if you'd prefer it land there.)
- **`src/llama-graph.cpp`** — guard `llm_graph_input_embd::set_input` on `embd != null` (mirrors the existing `can_reuse()` check), so gemma4's per-layer-token input — which reuses this class but only allocates `tokens` — can't deref a null `embd`.
- **`src/llama-context.cpp`** — re-reserve on a real `set_embeddings()` mode change (topology change); synchronize the main scheduler in `decode_mtp_async` before handoff so the MTP worker doesn't race the preceding decode's in-flight KV writes.
- **`convert_hf_to_gguf.py`** — register `Gemma4UnifiedAssistantForCausalLM` as an alias of `Gemma4AssistantForCausalLM` so newer assistant checkpoints convert.

## Note on branch overlap

The `build_graph` epilogue guard logically belongs with the MTP work on `feature/gemma-mtp`, and the `fattn.cu` change generalizes `fix/cuda-mma-dkq512-fallback`. I've targeted the default branch with the combined set for reviewability — happy to split into per-branch PRs if that fits your workflow better.

## Validation

Clean rebuild (all diagnostics stripped), 4/4 requests each, server healthy, clean shutdown:

- **E4B** (`gemma-4-E4B-it-Q4_K_M` + `gemma-4-E4B-it-assistant.Q4_K_M`): `Hello! How can I help you today? 😊`; `2, 3, 5`; `17+26 => 43`; draft acceptance 1/4–12/44.
- **12B** (`gemma-4-12b-it-IQ4_XS` + converted `gemma-4-12B-it-assistant-f16`): exercises **both** the fattn DKQ=512 fix (`gqa_ratio=8`) and the pooling fix; `17+26 => 43`; draft acceptance 22/36–49/58. (Empty content on some prompts is thinking-mode token-budget behavior — 12B has `thinking=1` and burns the 80-tok cap on `<channel>thought` — not a crash.)

Tested on RTX 5070 Ti (Blackwell sm_120), CUDA 13.3, but the epilogue guard is not GPU-specific — it would affect any Gemma-4 MTP target on any backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)