### PR TITLE
fix(gemma4-mtp): resolve PARALLEL=2 multi-slot crash in Gemma 4 MTP speculative decoding

### DIFF
--- a/src/llama-context.cpp
+++ b/src/llama-context.cpp
@@ -1279,14 +1279,6 @@ bool llama_context::ensure_sched_mtp() {
             return false;
         }
 
-        llama_memory_context_ptr mctx = memory->init_full();
-        if (!mctx) {
-            LLAMA_LOG_ERROR("%s: failed to init memory context for MTP reserve\n", __func__);
-            sched_mtp.reset();
-            gf_res_prev_mtp.reset();
-            return false;
-        }
-
         const uint32_t n_bb = model.mtp_assistant->hparams.n_embd_backbone;
         auto data = std::make_shared<llama_ubatch::data_t>();
         data->token.resize(1);
@@ -1320,6 +1312,14 @@ bool llama_context::ensure_sched_mtp() {
         ub.seq_idx      = data->seq_idx.data();
         ub.output       = data->output.data();
         ub.data         = data;
+
+        llama_memory_context_ptr mctx = kv_iswa->init_mtp(0, ub);
+        if (!mctx) {
+            LLAMA_LOG_ERROR("%s: failed to init memory context for MTP reserve\n", __func__);
+            sched_mtp.reset();
+            gf_res_prev_mtp.reset();
+            return false;
+        }
 
         const uint32_t save_n_outputs = n_outputs;
         n_outputs = 1;

--- a/src/llama-graph.cpp
+++ b/src/llama-graph.cpp
@@ -947,6 +947,7 @@ void llm_graph_result::set_params(const llm_graph_params & params) {
 
 llm_graph_context::llm_graph_context(const llm_graph_params & params) :
     arch             (params.arch),
+    gtype            (params.gtype),
     hparams          (params.hparams),
     cparams          (params.cparams),
     ubatch           (params.ubatch),
@@ -1899,7 +1900,7 @@ ggml_tensor * llm_graph_context::build_attn_mha(
     const bool v_trans = v->nb[1] > v->nb[2];
 
     // split the batch into streams if needed
-    const auto n_stream = k->ne[3];
+    const auto n_stream = (gtype == LLM_GRAPH_TYPE_MTP) ? 1 : k->ne[3];
 
     q = ggml_view_4d(ctx0, q, q->ne[0], q->ne[1], q->ne[2]/n_stream, n_stream, q->nb[1], q->nb[2], q->nb[3]/n_stream, 0);
 
@@ -1930,7 +1931,6 @@ ggml_tensor * llm_graph_context::build_attn_mha(
         if (v->type == GGML_TYPE_F32) {
             v = ggml_cast(ctx0, v, GGML_TYPE_F16);
         }
-
         cur = ggml_flash_attn_ext(ctx0, q, k, v, kq_mask, kq_scale, hparams.f_max_alibi_bias,
                                   hparams.attn_soft_cap ? hparams.f_attn_logit_softcapping : 0.0f);
         cb(cur, LLAMA_TENSOR_NAME_FATTN, il);

--- a/src/llama-graph.h
+++ b/src/llama-graph.h
@@ -742,6 +742,7 @@ using llm_graph_get_rows_fn = std::function<ggml_tensor * (ggml_context *, ggml_
 
 struct llm_graph_context {
     const llm_arch arch;
+    const llm_graph_type gtype;
 
     const llama_hparams & hparams;
     const llama_cparams & cparams;

--- a/src/models/gemma4-assistant.cpp
+++ b/src/models/gemma4-assistant.cpp
@@ -106,7 +106,7 @@ static void gemma4_mtp_build_one_step(
         ggml_tensor * Qcur = gctx.build_lora_mm(mtp.layers[il].wq, cur);
         cb(Qcur, "Qcur", il);
 
-        Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);
+        Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, 1);
 
         Qcur = gctx.build_norm(Qcur, mtp.layers[il].attn_q_norm, nullptr, LLM_NORM_RMS, il);
         cb(Qcur, "Qcur_normed", il);


### PR DESCRIPTION
## What this fixes

Running `llama-server` with `--n-parallel 2` and a Gemma 4 MTP assistant head crashed immediately when the second slot began its first speculative draft step:

```
GGML_ASSERT(ggml_nelements(a) == ne0*ne1*ne2) failed
ggml_reshape_3d() — ggml.c:3665
llm_build_gemma4_mtp::llm_build_gemma4_mtp()
llama_context::ensure_sched_mtp()
llama_context::decode_mtp_async()
```

Reproducible in 18 tokens on any two-slot request.

## Root cause (3 related issues)

**1. `gemma4-assistant.cpp` — wrong token dimension in Qcur reshape**

The MTP draft step always processes a single token column. The reshape was using `n_tokens` (the main batch size, which is `2` under `--n-parallel 2`) as the third dimension:

```cpp
// before
Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, n_tokens);

// after
Qcur = ggml_reshape_3d(ctx0, Qcur, n_embd_head, n_head, 1);
```

`n_tokens` is correct for the main model forward pass. For the MTP head it is always `1` — the draft head speculates one token position at a time regardless of how many slots the server is running.

**2. `llama-graph.cpp/h` — stream partition size for MTP models**

`n_stream` was not being set to `1` for MTP graphs, causing batch dimension splitting in self-attention/MHA that produced mismatched shapes under multi-slot scheduling.

**3. `llama-context.cpp` — reservation graph shape mismatch**

Scheduling reservations were using `init_full` instead of `init_mtp`, causing the reservation graph shape to differ from the execution graph shape under `--n-parallel 2`.

## Testing

Tested on AMD Ryzen AI Max+ 395 (Strix Halo APU), Vulkan/RADV, with:
- Gemma 4 12B QAT Q4_0 + QAT-matched assistant head Q8_0
- `--n-parallel 2`, `--mtp-draft-n 3`, `--draft-p-min 0.75`

Server survived two-slot speculative decoding without crashing. Acceptance rates and decode throughput unchanged from single-slot baseline.

Note: PR #25 addresses a different crash path (null `embd` dereference in `llm_graph_input_embd::set_input`). These two fixes are independent.