### PR TITLE
quantize: expose NVFP4 as a quantization target

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -103,6 +103,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
@@ -292,7 +293,7 @@ jobs:
       - name: Sign binaries
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity; do
+          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity build/bin/llama-quantize; do
             if [ -f "$bin" ]; then
               codesign --force --options runtime --timestamp \
                 --entitlements .github/entitlements.plist \
@@ -312,6 +313,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           cd release
           zip -r ../llama-turboquant-macos-arm64.zip .
           tar -czf ../llama-turboquant-macos-arm64.tar.gz .

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -106,6 +106,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
@@ -290,7 +291,7 @@ jobs:
 
       - name: Sign binaries
         run: |
-          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity; do
+          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity build/bin/llama-quantize; do
             if [ -f "$bin" ]; then
               codesign --force --options runtime --timestamp \
                 --entitlements .github/entitlements.plist \
@@ -306,6 +307,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           cd release
           zip -r ../llama-turboquant-macos-arm64.zip .
           tar -czf ../llama-turboquant-macos-arm64.tar.gz .
@@ -321,7 +323,7 @@ jobs:
             --password "$APPLE_ID_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             --wait --timeout 10m
-          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity; do
+          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity build/bin/llama-quantize; do
             if [ -f "$bin" ]; then
               name=$(basename "$bin")
               zip -j "${name}.zip" "$bin"
@@ -392,7 +394,7 @@ jobs:
 
           ### What's included
           - \`llama-server\` with \`--cache-type-k turbo3\` / \`turbo4\` support
-          - \`llama-cli\`, \`llama-bench\`, \`llama-perplexity\`
+          - \`llama-cli\`, \`llama-bench\`, \`llama-perplexity\`, \`llama-quantize\`
           - All supported backends in one release:
 
           | Backend | Asset |

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -814,6 +814,7 @@ ggml_type llama_ftype_get_default_type(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q2_0: return GGML_TYPE_Q2_0;
 
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return GGML_TYPE_MXFP4;
+        case LLAMA_FTYPE_MOSTLY_NVFP4:     return GGML_TYPE_NVFP4;
 
         // K-quants
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -37,6 +37,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_0",     LLAMA_FTYPE_MOSTLY_Q4_0,     " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
+    { "NVFP4",    LLAMA_FTYPE_MOSTLY_NVFP4,    " 4.50 bpw NVIDIA FP4",  },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },
     { "IQ2_XXS",  LLAMA_FTYPE_MOSTLY_IQ2_XXS,  " 2.06 bpw quantization",            },


### PR DESCRIPTION
ggml has full NVFP4 quantization support (`quantize_nvfp4`, imatrix-aware, dispatched in `ggml_quantize_chunk`) but the ftype was never wired into `llama-quant.cpp` / `llama-quantize`, so the only way to get an NVFP4 GGUF was converting NVIDIA's pre-quantized checkpoints.

- `src/llama-quant.cpp`: map `LLAMA_FTYPE_MOSTLY_NVFP4` -> `GGML_TYPE_NVFP4`
- `tools/quantize/quantize.cpp`: list `NVFP4` in the CLI type table
- `dev-build.yml` / `release-turboquant.yml`: ship `llama-quantize` in the linux/macos archives (windows already ships it) so downloaded dev builds can produce test quants standalone

Verified locally with the dev-latest binary (b10018-1.0.0, a4359555b): SmolLM2-135M f16 -> NVFP4 = 259MB -> 88MB (1 tensor fallback, expected for embeddings), coherent generation via llama-cli (198 t/s CPU) and llama-server `/v1/chat/completions`.