### PR TITLE
ci: add linux-x64-cuda-13.3 build (dev + release)

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -119,7 +119,8 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 14
 
-  linux-x64-cuda-13.3:
+  linux-x64-cuda-13-3:
+    name: linux-x64-cuda-13.3
     runs-on: ubuntu-22.04
 
     steps:
@@ -418,7 +419,7 @@ jobs:
   # broken backend never blocks the others from shipping to testers — the
   # release notes call out what is missing.
   publish-dev-latest:
-    needs: [linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
+    needs: [linux-x64-vulkan, linux-x64-cuda-13-3, windows-x64, macos-arm64]
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -119,6 +119,87 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 14
 
+  linux-x64-cuda-13.3:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: turboquant-linux-x64-cuda-13.3
+          evict-old-files: 1d
+
+      - name: Install CUDA Toolkit
+        run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential \
+            cuda-nvcc-13-3 cuda-cccl-13-3 cuda-cudart-dev-13-3 libcublas-dev-13-3
+          echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
+
+      - name: Build
+        # Arch set: A100 (80), RTX 30 (86), RTX 40 (89), H100/H200 (90),
+        # RTX 50 / Blackwell (120). Runner has no GPU -- build only, the
+        # backend is a dlopen'd libggml-cuda.so thanks to GGML_BACKEND_DL.
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_CUDA=ON \
+            -DGGML_CUDA_CUB_3DOT2=ON \
+            -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90;120" \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
+            -DLLAMA_CURL=OFF \
+            -DLLAMA_OPENSSL=OFF \
+            -DLLAMA_BUILD_SERVER=ON \
+            -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Verify build
+        run: |
+          ./build/bin/llama-server --version 2>&1 || true
+          ls -l build/bin/libggml-cuda.so
+
+      - name: Prepare archive
+        run: |
+          mkdir -p release/build/bin
+          cp build/bin/llama-server release/build/bin/
+          cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
+          find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
+          # CUDA runtime is not a given on user systems -- bundle it like the
+          # Windows job bundles cudart/cublas DLLs.
+          cp -P /usr/local/cuda/lib64/libcudart.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublas.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
+          cp LICENSE release/build/bin/ 2>/dev/null || true
+          cd release
+          zip -r ../llama-turboquant-linux-x64-cuda-13.3.zip .
+          tar -czf ../llama-turboquant-linux-x64-cuda-13.3.tar.gz .
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-linux-x64-cuda-13.3
+          path: |
+            llama-turboquant-linux-x64-cuda-13.3.zip
+            llama-turboquant-linux-x64-cuda-13.3.tar.gz
+          retention-days: 14
+
   windows-x64:
     runs-on: windows-2022
 
@@ -337,7 +418,7 @@ jobs:
   # broken backend never blocks the others from shipping to testers — the
   # release notes call out what is missing.
   publish-dev-latest:
-    needs: [linux-x64-vulkan, windows-x64, macos-arm64]
+    needs: [linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -122,6 +122,88 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 30
 
+  linux-x64-cuda-13.3:
+    needs: verify-version
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: turboquant-linux-x64-cuda-13.3
+          evict-old-files: 1d
+
+      - name: Install CUDA Toolkit
+        run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential \
+            cuda-nvcc-13-3 cuda-cccl-13-3 cuda-cudart-dev-13-3 libcublas-dev-13-3
+          echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
+
+      - name: Build
+        # Arch set: A100 (80), RTX 30 (86), RTX 40 (89), H100/H200 (90),
+        # RTX 50 / Blackwell (120). Runner has no GPU -- build only, the
+        # backend is a dlopen'd libggml-cuda.so thanks to GGML_BACKEND_DL.
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_CUDA=ON \
+            -DGGML_CUDA_CUB_3DOT2=ON \
+            -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90;120" \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
+            -DLLAMA_CURL=OFF \
+            -DLLAMA_OPENSSL=OFF \
+            -DLLAMA_BUILD_SERVER=ON \
+            -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Verify build
+        run: |
+          ./build/bin/llama-server --version 2>&1 || true
+          ls -l build/bin/libggml-cuda.so
+
+      - name: Prepare archive
+        run: |
+          mkdir -p release/build/bin
+          cp build/bin/llama-server release/build/bin/
+          cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
+          find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
+          # CUDA runtime is not a given on user systems -- bundle it like the
+          # Windows job bundles cudart/cublas DLLs.
+          cp -P /usr/local/cuda/lib64/libcudart.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublas.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
+          cp LICENSE release/build/bin/ 2>/dev/null || true
+          cd release
+          zip -r ../llama-turboquant-linux-x64-cuda-13.3.zip .
+          tar -czf ../llama-turboquant-linux-x64-cuda-13.3.tar.gz .
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-linux-x64-cuda-13.3
+          path: |
+            llama-turboquant-linux-x64-cuda-13.3.zip
+            llama-turboquant-linux-x64-cuda-13.3.tar.gz
+          retention-days: 14
+
   windows-x64:
     needs: verify-version
     runs-on: windows-2022
@@ -353,7 +435,7 @@ jobs:
   # A stable release must be COMPLETE: this job has hard `needs` on every
   # build job — if anything failed, no release is published at all.
   publish-release:
-    needs: [verify-version, linux-x64-vulkan, windows-x64, macos-arm64]
+    needs: [verify-version, linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -122,7 +122,8 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 30
 
-  linux-x64-cuda-13.3:
+  linux-x64-cuda-13-3:
+    name: linux-x64-cuda-13.3
     needs: verify-version
     runs-on: ubuntu-22.04
 
@@ -435,7 +436,7 @@ jobs:
   # A stable release must be COMPLETE: this job has hard `needs` on every
   # build job — if anything failed, no release is published at all.
   publish-release:
-    needs: [verify-version, linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
+    needs: [verify-version, linux-x64-vulkan, linux-x64-cuda-13-3, windows-x64, macos-arm64]
     runs-on: ubuntu-22.04
     permissions:
       contents: write


### PR DESCRIPTION
Linux currently ships only `linux-x64-vulkan`; NVIDIA users never get native CUDA kernels — including native FP4 on Blackwell, which the Vulkan path cannot use (`fp4: 0` in device caps, verified on a rented RTX 5090).

Adds a `linux-x64-cuda-13.3` job to `dev-build.yml` and `release-turboquant.yml`, mirroring the Windows `cuda-13.3` variant:

- `GGML_BACKEND_DL=ON`: CUDA backend is a dlopen'd `libggml-cuda.so` next to the CPU variants — one archive, backend picked at runtime
- `CMAKE_CUDA_ARCHITECTURES=80;86;89;90;120` (A100 / RTX 30 / RTX 40 / H100+H200 / RTX 50)
- bundles `libcudart`/`libcublas`/`libcublasLt` like the Windows job bundles the DLLs
- new asset: `llama-turboquant-linux-x64-cuda-13.3.{tar.gz,zip}`, artifact `archive-linux-x64-cuda-13.3`, added to both publish jobs' `needs`

Note: first CI run builds cold (no ccache) — expect the new job to take a while; subsequent runs drop to minutes. The job is intentionally NOT in the required-checks list yet — add it after it proves stable.

After merge the plan is: manually smoke the new artifact on a rented 5090 (native FP4 path), then wire both linux artifacts into the upcoming `backend-smoke.yml`.