### PR TITLE
smoke: fix CUDA device assert and tg128 column

### DIFF
--- a/.github/scripts/gpu-smoke/remote-smoke.sh
+++ b/.github/scripts/gpu-smoke/remote-smoke.sh
@@ -85,11 +85,12 @@ case "$BACKEND" in
     ;;
   linux-x64-cuda-13.3)
     grep -q "load_backend: loaded CUDA backend" bench.log || fail "CUDA backend not loaded"
-    grep -Eiq "cuda.*(NVIDIA|GeForce|RTX|H[0-9]+)" bench.log || fail "CUDA device is not an NVIDIA GPU"
+    # bench log format: "  Device 0: NVIDIA GeForce RTX 5090, compute capability 12.0"
+    grep -Eq "Device [0-9]+: NVIDIA" bench.log || fail "CUDA device is not an NVIDIA GPU"
     ;;
   *) fail "unknown backend $BACKEND" ;;
 esac
-TG=$(awk -F'|' '/tg128/ {gsub(/ /,"",$7); print $7}' bench.log | head -1)
+TG=$(awk -F'|' '/tg128/ {gsub(/^ +| +$/,"",$8); split($8,a," "); print a[1]; exit}' bench.log)
 echo "tg128: ${TG:-?} t/s"
 
 echo "SMOKE OK: $BACKEND @ $TAG ($VERSION_LINE)"


### PR DESCRIPTION
Manual validation run of the committed smoke scripts on a rented RTX 5090 (dev-latest, commit f2757dfb0):

- **linux-x64-vulkan: SMOKE OK** — pp512 25.4k t/s, tg128 674 t/s
- **linux-x64-cuda-13.3: worked perfectly** (CUDA backend loaded, pp512 **60.5k t/s**, tg128 **1349 t/s** — 2.2–2.4× the Vulkan path on the same GPU) — but was reported FAIL by a bug in my assert: the regex required `cuda` and `NVIDIA` on the same log line, while the bench log prints the device as `Device 0: NVIDIA GeForce RTX 5090, compute capability 12.0`.

Fixes:
- CUDA device assert → `Device [0-9]+: NVIDIA` (validated against the real bench.log from the failing run)
- tg128 extraction read the test-name column ($7) instead of the t/s column ($8)