### PR TITLE
Promote dev: NVFP4 quantize target, linux-x64-cuda-13.3 build, GPU smoke CI, laguna test fix

### DIFF
--- a/.github/scripts/gpu-smoke/remote-smoke.sh
+++ b/.github/scripts/gpu-smoke/remote-smoke.sh
@@ -85,11 +85,12 @@ case "$BACKEND" in
     ;;
   linux-x64-cuda-13.3)
     grep -q "load_backend: loaded CUDA backend" bench.log || fail "CUDA backend not loaded"
-    grep -Eiq "cuda.*(NVIDIA|GeForce|RTX|H[0-9]+)" bench.log || fail "CUDA device is not an NVIDIA GPU"
+    # bench log format: "  Device 0: NVIDIA GeForce RTX 5090, compute capability 12.0"
+    grep -Eq "Device [0-9]+: NVIDIA" bench.log || fail "CUDA device is not an NVIDIA GPU"
     ;;
   *) fail "unknown backend $BACKEND" ;;
 esac
-TG=$(awk -F'|' '/tg128/ {gsub(/ /,"",$7); print $7}' bench.log | head -1)
+TG=$(awk -F'|' '/tg128/ {gsub(/^ +| +$/,"",$8); split($8,a," "); print a[1]; exit}' bench.log)
 echo "tg128: ${TG:-?} t/s"
 
 echo "SMOKE OK: $BACKEND @ $TAG ($VERSION_LINE)"

--- a/.github/scripts/gpu-smoke/remote-smoke.sh
+++ b/.github/scripts/gpu-smoke/remote-smoke.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# Runs ON the rented GPU box. Smokes one released backend archive end-to-end:
+#   download release asset -> quantize f16 -> NVFP4 with the SHIPPED
+#   llama-quantize -> llama-server on GPU -> coherence assert -> llama-bench
+#   -> assert the GPU backend actually did the work (no silent CPU fallback).
+#
+# args: $1 = backend id (linux-x64-vulkan | linux-x64-cuda-13.3)
+#       $2 = release tag (e.g. dev-latest or b10018-1.0.0)
+# Writes /root/smoke.log (progress) and /root/smoke.status (OK/FAIL last line).
+set -uo pipefail   # NOT -e: we handle failures explicitly to always write status
+
+BACKEND="${1:?backend id required}"
+TAG="${2:-dev-latest}"
+REPO="AtomicBot-ai/atomic-llama-cpp-turboquant"
+WORK=/root/smoke
+BIN="$WORK/bin/build/bin"
+
+fail() { echo "FAIL: $*"; echo "FAIL" > /root/smoke.status; exit 1; }
+
+mkdir -p "$WORK" && cd "$WORK"
+export DEBIAN_FRONTEND=noninteractive
+
+echo "== [1/6] runtime deps for $BACKEND =="
+apt-get update -q >/dev/null 2>&1 || true
+apt-get install -yq curl jq >/dev/null 2>&1 || fail "apt basic deps"
+if [ "$BACKEND" = "linux-x64-vulkan" ]; then
+  # Lessons from manual runs on vast boxes:
+  #  - libGLX_nvidia (the vulkan ICD) silently needs X11 client libs
+  #  - the stock jammy vulkan loader (1.3.204) cannot negotiate with the ICD
+  #    of current NVIDIA drivers -> take the loader from LunarG
+  apt-get install -yq libvulkan1 libxext6 libx11-6 wget gnupg >/dev/null 2>&1 || fail "apt vulkan deps"
+  wget -qO - https://packages.lunarg.com/lunarg-signing-key-pub.asc | apt-key add - >/dev/null 2>&1
+  wget -qO /etc/apt/sources.list.d/lunarg-vulkan-jammy.list \
+    https://packages.lunarg.com/vulkan/lunarg-vulkan-jammy.list
+  apt-get update -q >/dev/null 2>&1
+  apt-get install -yq vulkan-sdk >/dev/null 2>&1 || fail "apt vulkan-sdk (LunarG)"
+fi
+# CUDA backend: driver comes from the host, cudart/cublas are bundled in the archive.
+
+echo "== [2/6] release asset =="
+curl -sfLo bin.tar.gz \
+  "https://github.com/$REPO/releases/download/$TAG/llama-turboquant-$BACKEND.tar.gz" \
+  || fail "asset download llama-turboquant-$BACKEND.tar.gz @ $TAG"
+mkdir -p bin && tar xzf bin.tar.gz -C bin || fail "unpack"
+VERSION_LINE=$("$BIN/llama-server" --version 2>&1 | head -1)
+echo "version: $VERSION_LINE"
+echo "$VERSION_LINE" | grep -q "version:" || fail "llama-server --version"
+
+echo "== [3/6] f16 -> NVFP4 with shipped llama-quantize =="
+curl -sfLo m-f16.gguf \
+  "https://huggingface.co/bartowski/SmolLM2-135M-Instruct-GGUF/resolve/main/SmolLM2-135M-Instruct-f16.gguf" \
+  || fail "model download"
+"$BIN/llama-quantize" m-f16.gguf m-nvfp4.gguf NVFP4 >quant.log 2>&1 || fail "llama-quantize NVFP4"
+[ -s m-nvfp4.gguf ] || fail "nvfp4 gguf empty"
+ls -lh m-*.gguf
+
+echo "== [4/6] llama-server on GPU =="
+"$BIN/llama-server" -m m-nvfp4.gguf --port 8099 --no-webui -ngl 99 >server.log 2>&1 &
+SRV=$!
+UP=""
+for i in $(seq 1 90); do
+  if curl -sf http://127.0.0.1:8099/health >/dev/null 2>&1; then UP=1; break; fi
+  kill -0 $SRV 2>/dev/null || break
+  sleep 2
+done
+[ -n "$UP" ] || { tail -20 server.log; fail "server did not become healthy"; }
+echo "health: ok"
+
+echo "== [5/6] generation + coherence assert =="
+ANSWER=$(curl -sf http://127.0.0.1:8099/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{"messages":[{"role":"user","content":"What is the capital of France? Reply with just the city name."}],"max_tokens":20,"temperature":0}' \
+  | jq -r '.choices[0].message.content // empty')
+echo "answer: $ANSWER"
+echo "$ANSWER" | grep -qi paris || { kill $SRV 2>/dev/null; fail "answer lacks 'Paris'"; }
+kill $SRV 2>/dev/null; wait $SRV 2>/dev/null
+
+echo "== [6/6] llama-bench + GPU-actually-used assert =="
+"$BIN/llama-bench" -m m-nvfp4.gguf -ngl 99 -p 512 -n 128 >bench.log 2>&1 || fail "llama-bench"
+sed -n '/| model/,$p' bench.log
+case "$BACKEND" in
+  linux-x64-vulkan)
+    grep -q "load_backend: loaded Vulkan backend" bench.log || fail "Vulkan backend not loaded"
+    grep -Eq "ggml_vulkan: 0 = NVIDIA" bench.log || fail "Vulkan device is not the NVIDIA GPU"
+    ;;
+  linux-x64-cuda-13.3)
+    grep -q "load_backend: loaded CUDA backend" bench.log || fail "CUDA backend not loaded"
+    grep -Eiq "cuda.*(NVIDIA|GeForce|RTX|H[0-9]+)" bench.log || fail "CUDA device is not an NVIDIA GPU"
+    ;;
+  *) fail "unknown backend $BACKEND" ;;
+esac
+TG=$(awk -F'|' '/tg128/ {gsub(/ /,"",$7); print $7}' bench.log | head -1)
+echo "tg128: ${TG:-?} t/s"
+
+echo "SMOKE OK: $BACKEND @ $TAG ($VERSION_LINE)"
+echo "OK" > /root/smoke.status

--- a/.github/scripts/gpu-smoke/rent.sh
+++ b/.github/scripts/gpu-smoke/rent.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Rent ONE vast.ai GPU box for the smoke test: walk the cheapest offers,
+# create sequentially, first to reach `running` + answer ssh wins.
+# Losers/failures are destroyed. Simpler sibling of atomic-forge's
+# rent_race.sh (we need one short-lived box, not a race).
+#
+# env in : VAST_API_KEY, GPU_QUERY, SSH_KEY_FILE, [DISK_GB=40] [MAX_OFFERS=5]
+# out    : iid/host/port appended to $GITHUB_OUTPUT
+set -euo pipefail
+
+DISK_GB="${DISK_GB:-40}"
+MAX_OFFERS="${MAX_OFFERS:-5}"
+IMAGE="nvidia/cuda:12.8.0-runtime-ubuntu22.04"
+
+vastai set api-key "$VAST_API_KEY" >/dev/null
+
+vastai search offers \
+  "$GPU_QUERY disk_space>=$DISK_GB inet_down>=500 reliability>0.98 rentable=true" \
+  -o dph --raw > offers.json
+N=$(jq 'length' offers.json)
+[ "$N" -gt 0 ] || { echo "::error::no vast offers match: $GPU_QUERY"; exit 1; }
+echo "offers found: $N, trying up to $MAX_OFFERS cheapest"
+
+IID=""
+cleanup() { [ -n "$IID" ] && vastai destroy instance "$IID" >/dev/null 2>&1 || true; }
+
+for i in $(seq 0 $((MAX_OFFERS - 1))); do
+  [ "$i" -lt "$N" ] || break
+  OFFER=$(jq -r ".[$i].id" offers.json)
+  DPH=$(jq -r ".[$i].dph_total" offers.json)
+  echo "--- offer $OFFER (\$${DPH}/h)"
+  if ! vastai create instance "$OFFER" --image "$IMAGE" \
+       --disk "$DISK_GB" --ssh --direct --raw > create.json 2>&1; then
+    echo "create failed, next offer"; continue
+  fi
+  IID=$(jq -r '.new_contract // empty' create.json)
+  [ -n "$IID" ] || { echo "no contract id, next offer"; continue; }
+
+  # created -> loading (image pull) -> running; give it 10 minutes
+  for tick in $(seq 1 40); do
+    ST=$(vastai show instance "$IID" --raw 2>/dev/null | jq -r '.actual_status // "?"')
+    [ "$ST" = "running" ] && break
+    sleep 15
+  done
+  if [ "$ST" != "running" ]; then
+    echo "offer $OFFER never reached running ($ST), destroying"
+    cleanup; IID=""; continue
+  fi
+
+  URL=$(vastai ssh-url "$IID")
+  HOST=$(echo "$URL" | sed -E 's|ssh://root@([^:]+):.*|\1|')
+  PORT=$(echo "$URL" | sed -E 's|.*:([0-9]+)$|\1|')
+
+  # ssh может подняться на минуту позже статуса running — пробуем с ретраями
+  OK=""
+  for try in $(seq 1 8); do
+    if ssh -o StrictHostKeyChecking=no -o ConnectTimeout=15 \
+           -i "$SSH_KEY_FILE" -p "$PORT" root@"$HOST" 'echo ssh-ok' 2>/dev/null | grep -q ssh-ok; then
+      OK=1; break
+    fi
+    sleep 15
+  done
+  if [ -z "$OK" ]; then
+    echo "offer $OFFER: ssh unreachable, destroying"
+    cleanup; IID=""; continue
+  fi
+
+  echo "rented: iid=$IID $HOST:$PORT"
+  { echo "iid=$IID"; echo "host=$HOST"; echo "port=$PORT"; } >> "$GITHUB_OUTPUT"
+  exit 0
+done
+
+echo "::error::all offers failed"
+exit 1

--- a/.github/workflows/backend-smoke.yml
+++ b/.github/workflows/backend-smoke.yml
@@ -1,0 +1,128 @@
+# GPU smoke test of RELEASED backend archives on a rented vast.ai box.
+#
+# Not a required check by design: spot GPU rental is nondeterministic and
+# costs money, so it runs on demand (button) and nightly — never as a PR
+# gate. The result is posted as a NON-required commit status
+# (gpu-smoke/<backend>) on the commit the tested release points at, so the
+# dev -> master promotion PR shows the badge.
+#
+# What one run does (see .github/scripts/gpu-smoke/):
+#   rent cheapest matching GPU -> download the released archive -> quantize
+#   a tiny f16 model to NVFP4 with the SHIPPED llama-quantize -> serve it
+#   with -ngl 99 -> assert a coherent answer -> llama-bench -> assert the
+#   GPU backend actually did the work (a silent CPU fallback must FAIL).
+#
+# Secrets: VAST_API_KEY, VAST_SSH_KEY (private key registered with vast).
+
+name: GPU smoke (vast.ai)
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to smoke'
+        default: 'dev-latest'
+      backends:
+        description: 'Backends to test (space-separated)'
+        default: 'linux-x64-vulkan linux-x64-cuda-13.3'
+      gpu_query:
+        description: 'vast.ai offer filter'
+        default: 'gpu_name=RTX_5090 num_gpus=1'
+  schedule:
+    # nightly against dev-latest; ~$1/night at current spot prices
+    - cron: '0 3 * * *'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.inputs.release_tag || 'dev-latest' }}
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      statuses: write
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: ['linux-x64-vulkan', 'linux-x64-cuda-13.3']
+    env:
+      RELEASE_TAG: ${{ github.event.inputs.release_tag || 'dev-latest' }}
+      BACKENDS: ${{ github.event.inputs.backends || 'linux-x64-vulkan linux-x64-cuda-13.3' }}
+      GPU_QUERY: ${{ github.event.inputs.gpu_query || 'gpu_name=RTX_5090 num_gpus=1' }}
+
+    steps:
+      - name: Skip if backend not selected
+        id: gate
+        run: |
+          if echo "$BACKENDS" | grep -qw "${{ matrix.backend }}"; then
+            echo "run=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "run=false" >> "$GITHUB_OUTPUT"
+            echo "backend ${{ matrix.backend }} not in '$BACKENDS' — skipping"
+          fi
+
+      - name: Clone
+        if: steps.gate.outputs.run == 'true'
+        uses: actions/checkout@v6
+
+      - name: Install vast CLI + ssh key
+        if: steps.gate.outputs.run == 'true'
+        run: |
+          pip install -q vastai
+          install -m 600 /dev/null vast_key
+          printf '%s\n' "${{ secrets.VAST_SSH_KEY }}" > vast_key
+
+      - name: Rent GPU box
+        if: steps.gate.outputs.run == 'true'
+        id: rent
+        env:
+          VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+          SSH_KEY_FILE: vast_key
+        run: bash .github/scripts/gpu-smoke/rent.sh
+
+      - name: Run smoke on box
+        if: steps.gate.outputs.run == 'true'
+        id: run_smoke
+        env:
+          HOST: ${{ steps.rent.outputs.host }}
+          PORT: ${{ steps.rent.outputs.port }}
+        run: |
+          SSH="ssh -o StrictHostKeyChecking=no -o ConnectTimeout=20 -o ServerAliveInterval=30 -i vast_key -p $PORT root@$HOST"
+          scp -o StrictHostKeyChecking=no -i vast_key -P "$PORT" \
+            .github/scripts/gpu-smoke/remote-smoke.sh root@"$HOST":/root/remote-smoke.sh
+          # vast hosts are known to drop long ssh sessions -> nohup + poll
+          $SSH "nohup bash /root/remote-smoke.sh '${{ matrix.backend }}' '$RELEASE_TAG' >/root/smoke.log 2>&1 &"
+          for i in $(seq 1 60); do
+            STATUS=$($SSH 'cat /root/smoke.status 2>/dev/null' 2>/dev/null || true)
+            [ -n "$STATUS" ] && break
+            sleep 20
+          done
+          echo "===== smoke.log ====="
+          $SSH 'cat /root/smoke.log' 2>/dev/null || true
+          echo "====================="
+          [ "$STATUS" = "OK" ] || { echo "::error::smoke failed for ${{ matrix.backend }}"; exit 1; }
+
+      - name: Post commit status
+        if: always() && steps.gate.outputs.run == 'true' && steps.rent.outcome == 'success'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          SHA=$(gh api "repos/${{ github.repository }}/commits/$RELEASE_TAG" --jq .sha 2>/dev/null || true)
+          [ -n "$SHA" ] || { echo "cannot resolve $RELEASE_TAG to a commit, skipping status"; exit 0; }
+          STATE=failure
+          [ "${{ steps.run_smoke.outcome }}" = "success" ] && STATE=success
+          gh api "repos/${{ github.repository }}/statuses/$SHA" \
+            -f state="$STATE" \
+            -f context="gpu-smoke/${{ matrix.backend }}" \
+            -f description="NVFP4 smoke on rented GPU ($RELEASE_TAG)" \
+            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+
+      - name: Destroy GPU box
+        if: always() && steps.rent.outputs.iid != ''
+        env:
+          VAST_API_KEY: ${{ secrets.VAST_API_KEY }}
+        run: |
+          vastai set api-key "$VAST_API_KEY" >/dev/null
+          vastai destroy instance "${{ steps.rent.outputs.iid }}" || true
+          echo "destroyed instance ${{ steps.rent.outputs.iid }}"

--- a/.github/workflows/build-vulkan.yml
+++ b/.github/workflows/build-vulkan.yml
@@ -17,12 +17,12 @@ on:
       '**/*.glsl'
     ]
 
+  # No paths filter: ubuntu-llvmpipe/ubuntu-arm64 are required status checks
+  # on dev, and a required check that never reports leaves the PR stuck in
+  # "Expected" forever (e.g. a docs-only PR). This is also the only PR job
+  # that runs the full ctest suite, so running it on every PR is intended.
   pull_request:
     types: [opened, synchronize, reopened]
-    paths: [
-      '.github/workflows/build-vulkan.yml',
-      'ggml/src/ggml-vulkan/**'
-    ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref && github.ref || github.run_id }}

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -119,7 +119,8 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 14
 
-  linux-x64-cuda-13.3:
+  linux-x64-cuda-13-3:
+    name: linux-x64-cuda-13.3
     runs-on: ubuntu-22.04
 
     steps:
@@ -418,7 +419,7 @@ jobs:
   # broken backend never blocks the others from shipping to testers — the
   # release notes call out what is missing.
   publish-dev-latest:
-    needs: [linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
+    needs: [linux-x64-vulkan, linux-x64-cuda-13-3, windows-x64, macos-arm64]
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -103,6 +103,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
@@ -292,7 +293,7 @@ jobs:
       - name: Sign binaries
         if: ${{ github.event_name != 'pull_request' }}
         run: |
-          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity; do
+          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity build/bin/llama-quantize; do
             if [ -f "$bin" ]; then
               codesign --force --options runtime --timestamp \
                 --entitlements .github/entitlements.plist \
@@ -312,6 +313,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           cd release
           zip -r ../llama-turboquant-macos-arm64.zip .
           tar -czf ../llama-turboquant-macos-arm64.tar.gz .

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -119,6 +119,87 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 14
 
+  linux-x64-cuda-13.3:
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: turboquant-linux-x64-cuda-13.3
+          evict-old-files: 1d
+
+      - name: Install CUDA Toolkit
+        run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential \
+            cuda-nvcc-13-3 cuda-cccl-13-3 cuda-cudart-dev-13-3 libcublas-dev-13-3
+          echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
+
+      - name: Build
+        # Arch set: A100 (80), RTX 30 (86), RTX 40 (89), H100/H200 (90),
+        # RTX 50 / Blackwell (120). Runner has no GPU -- build only, the
+        # backend is a dlopen'd libggml-cuda.so thanks to GGML_BACKEND_DL.
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_CUDA=ON \
+            -DGGML_CUDA_CUB_3DOT2=ON \
+            -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90;120" \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
+            -DLLAMA_CURL=OFF \
+            -DLLAMA_OPENSSL=OFF \
+            -DLLAMA_BUILD_SERVER=ON \
+            -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Verify build
+        run: |
+          ./build/bin/llama-server --version 2>&1 || true
+          ls -l build/bin/libggml-cuda.so
+
+      - name: Prepare archive
+        run: |
+          mkdir -p release/build/bin
+          cp build/bin/llama-server release/build/bin/
+          cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
+          find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
+          # CUDA runtime is not a given on user systems -- bundle it like the
+          # Windows job bundles cudart/cublas DLLs.
+          cp -P /usr/local/cuda/lib64/libcudart.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublas.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
+          cp LICENSE release/build/bin/ 2>/dev/null || true
+          cd release
+          zip -r ../llama-turboquant-linux-x64-cuda-13.3.zip .
+          tar -czf ../llama-turboquant-linux-x64-cuda-13.3.tar.gz .
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-linux-x64-cuda-13.3
+          path: |
+            llama-turboquant-linux-x64-cuda-13.3.zip
+            llama-turboquant-linux-x64-cuda-13.3.tar.gz
+          retention-days: 14
+
   windows-x64:
     runs-on: windows-2022
 
@@ -337,7 +418,7 @@ jobs:
   # broken backend never blocks the others from shipping to testers — the
   # release notes call out what is missing.
   publish-dev-latest:
-    needs: [linux-x64-vulkan, windows-x64, macos-arm64]
+    needs: [linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
     if: ${{ always() && github.event_name == 'push' && github.ref == 'refs/heads/dev' }}
     runs-on: ubuntu-22.04
     permissions:

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -27,22 +27,14 @@ on:
       - '**/*.comp'
       - '**/*.glsl'
       - '**/*.metal'
+  # No paths filter: these jobs are required status checks on dev, and a
+  # required check that never reports leaves the PR stuck in "Expected"
+  # forever (e.g. a docs-only PR). Runs on PRs into master too so the
+  # dev -> master promotion PR reports the same checks.
   pull_request:
     branches:
       - dev
-    paths:
-      - '.github/workflows/dev-build.yml'
-      - '.github/actions/windows-setup-cuda/**'
-      - '**/CMakeLists.txt'
-      - '**/*.h'
-      - '**/*.hpp'
-      - '**/*.c'
-      - '**/*.cpp'
-      - '**/*.cu'
-      - '**/*.cuh'
-      - '**/*.comp'
-      - '**/*.glsl'
-      - '**/*.metal'
+      - master
 
 # Group by ref so consecutive pushes to dev serialize: a newer push cancels
 # the older in-flight build instead of racing it for the dev-latest release.

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -122,6 +122,88 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 30
 
+  linux-x64-cuda-13.3:
+    needs: verify-version
+    runs-on: ubuntu-22.04
+
+    steps:
+      - name: Clone
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: ccache
+        uses: ggml-org/ccache-action@v1.2.21
+        with:
+          key: turboquant-linux-x64-cuda-13.3
+          evict-old-files: 1d
+
+      - name: Install CUDA Toolkit
+        run: |
+          wget -q https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb
+          sudo dpkg -i cuda-keyring_1.1-1_all.deb
+          sudo apt-get update -y
+          sudo apt-get install -y build-essential \
+            cuda-nvcc-13-3 cuda-cccl-13-3 cuda-cudart-dev-13-3 libcublas-dev-13-3
+          echo "/usr/local/cuda/bin" >> "$GITHUB_PATH"
+
+      - name: Build
+        # Arch set: A100 (80), RTX 30 (86), RTX 40 (89), H100/H200 (90),
+        # RTX 50 / Blackwell (120). Runner has no GPU -- build only, the
+        # backend is a dlopen'd libggml-cuda.so thanks to GGML_BACKEND_DL.
+        run: |
+          cmake -B build \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DCMAKE_INSTALL_RPATH='$ORIGIN' \
+            -DCMAKE_BUILD_WITH_INSTALL_RPATH=ON \
+            -DGGML_BACKEND_DL=ON \
+            -DGGML_NATIVE=OFF \
+            -DGGML_CPU_ALL_VARIANTS=ON \
+            -DGGML_CUDA=ON \
+            -DGGML_CUDA_CUB_3DOT2=ON \
+            -DCMAKE_CUDA_ARCHITECTURES="80;86;89;90;120" \
+            -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
+            -DLLAMA_CURL=OFF \
+            -DLLAMA_OPENSSL=OFF \
+            -DLLAMA_BUILD_SERVER=ON \
+            -DLLAMA_BUILD_TOOLS=ON \
+            -DLLAMA_BUILD_TESTS=OFF \
+            -DLLAMA_BUILD_EXAMPLES=OFF
+          cmake --build build --config Release -j $(nproc)
+
+      - name: Verify build
+        run: |
+          ./build/bin/llama-server --version 2>&1 || true
+          ls -l build/bin/libggml-cuda.so
+
+      - name: Prepare archive
+        run: |
+          mkdir -p release/build/bin
+          cp build/bin/llama-server release/build/bin/
+          cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
+          find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
+          # CUDA runtime is not a given on user systems -- bundle it like the
+          # Windows job bundles cudart/cublas DLLs.
+          cp -P /usr/local/cuda/lib64/libcudart.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublas.so* release/build/bin/
+          cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
+          cp LICENSE release/build/bin/ 2>/dev/null || true
+          cd release
+          zip -r ../llama-turboquant-linux-x64-cuda-13.3.zip .
+          tar -czf ../llama-turboquant-linux-x64-cuda-13.3.tar.gz .
+
+      - name: Upload archive
+        uses: actions/upload-artifact@v4
+        with:
+          name: archive-linux-x64-cuda-13.3
+          path: |
+            llama-turboquant-linux-x64-cuda-13.3.zip
+            llama-turboquant-linux-x64-cuda-13.3.tar.gz
+          retention-days: 14
+
   windows-x64:
     needs: verify-version
     runs-on: windows-2022
@@ -353,7 +435,7 @@ jobs:
   # A stable release must be COMPLETE: this job has hard `needs` on every
   # build job — if anything failed, no release is published at all.
   publish-release:
-    needs: [verify-version, linux-x64-vulkan, windows-x64, macos-arm64]
+    needs: [verify-version, linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -122,7 +122,8 @@ jobs:
             llama-turboquant-linux-x64-vulkan.tar.gz
           retention-days: 30
 
-  linux-x64-cuda-13.3:
+  linux-x64-cuda-13-3:
+    name: linux-x64-cuda-13.3
     needs: verify-version
     runs-on: ubuntu-22.04
 
@@ -435,7 +436,7 @@ jobs:
   # A stable release must be COMPLETE: this job has hard `needs` on every
   # build job — if anything failed, no release is published at all.
   publish-release:
-    needs: [verify-version, linux-x64-vulkan, linux-x64-cuda-13.3, windows-x64, macos-arm64]
+    needs: [verify-version, linux-x64-vulkan, linux-x64-cuda-13-3, windows-x64, macos-arm64]
     runs-on: ubuntu-22.04
     permissions:
       contents: write

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -106,6 +106,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
@@ -290,7 +291,7 @@ jobs:
 
       - name: Sign binaries
         run: |
-          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity; do
+          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity build/bin/llama-quantize; do
             if [ -f "$bin" ]; then
               codesign --force --options runtime --timestamp \
                 --entitlements .github/entitlements.plist \
@@ -306,6 +307,7 @@ jobs:
           cp build/bin/llama-cli release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-bench release/build/bin/ 2>/dev/null || true
           cp build/bin/llama-perplexity release/build/bin/ 2>/dev/null || true
+          cp build/bin/llama-quantize release/build/bin/ 2>/dev/null || true
           cd release
           zip -r ../llama-turboquant-macos-arm64.zip .
           tar -czf ../llama-turboquant-macos-arm64.tar.gz .
@@ -321,7 +323,7 @@ jobs:
             --password "$APPLE_ID_PASSWORD" \
             --team-id "$APPLE_TEAM_ID" \
             --wait --timeout 10m
-          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity; do
+          for bin in build/bin/llama-server build/bin/llama-cli build/bin/llama-bench build/bin/llama-perplexity build/bin/llama-quantize; do
             if [ -f "$bin" ]; then
               name=$(basename "$bin")
               zip -j "${name}.zip" "$bin"
@@ -392,7 +394,7 @@ jobs:
 
           ### What's included
           - \`llama-server\` with \`--cache-type-k turbo3\` / \`turbo4\` support
-          - \`llama-cli\`, \`llama-bench\`, \`llama-perplexity\`
+          - \`llama-cli\`, \`llama-bench\`, \`llama-perplexity\`, \`llama-quantize\`
           - All supported backends in one release:
 
           | Backend | Asset |

--- a/src/llama-model-saver.cpp
+++ b/src/llama-model-saver.cpp
@@ -213,7 +213,7 @@ void llama_model_saver::add_kv_from_model() {
     add_kv(LLM_KV_FEED_FORWARD_LENGTH,               hparams.n_ff_arr, true);
     add_kv(LLM_KV_EXPERT_FEED_FORWARD_LENGTH,        hparams.n_ff_exp);
     add_kv(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_shexp);
-    add_kv(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, hparams.n_ff_chexp);
+    add_kv(LLM_KV_EXPERT_CHUNK_FEED_FORWARD_LENGTH,  hparams.n_ff_chexp);
     add_kv(LLM_KV_SWIGLU_CLAMP_EXP,                  hparams.swiglu_clamp_exp);
     add_kv(LLM_KV_SWIGLU_CLAMP_SHEXP,                hparams.swiglu_clamp_shexp);
     add_kv(LLM_KV_USE_PARALLEL_RESIDUAL,             hparams.use_par_res);

--- a/src/llama-quant.cpp
+++ b/src/llama-quant.cpp
@@ -814,6 +814,7 @@ ggml_type llama_ftype_get_default_type(llama_ftype ftype) {
         case LLAMA_FTYPE_MOSTLY_Q2_0: return GGML_TYPE_Q2_0;
 
         case LLAMA_FTYPE_MOSTLY_MXFP4_MOE: return GGML_TYPE_MXFP4;
+        case LLAMA_FTYPE_MOSTLY_NVFP4:     return GGML_TYPE_NVFP4;
 
         // K-quants
         case LLAMA_FTYPE_MOSTLY_Q2_K_S:

--- a/src/models/laguna.cpp
+++ b/src/models/laguna.cpp
@@ -101,9 +101,12 @@ void llama_model_laguna::load_arch_tensors(llama_model_loader & ml) {
         // `gating` type and fails at conversion time on a mismatch.)
         const int64_t n_gate_per_head = n_head_il;
         const int64_t n_gate_per_elem = n_embd_head_k * n_head_il;
+        // Metadata-only loads (test-llama-archs synthesizes models without a
+        // tensor map) have no meta to inspect -- default to per-head there. A
+        // real file with the gate tensor missing still fails hard in the
+        // required create_tensor below.
         const ggml_tensor * gate_meta = ml.get_tensor_meta(tn(LLM_TENSOR_ATTN_GATE, "weight", i).str().c_str());
-        GGML_ASSERT(gate_meta != nullptr && "Laguna: missing attention gate tensor");
-        const int64_t n_gate_out = gate_meta->ne[1];
+        const int64_t n_gate_out = gate_meta != nullptr ? gate_meta->ne[1] : n_gate_per_head;
         if (n_gate_out != n_gate_per_head && n_gate_out != n_gate_per_elem) {
             GGML_ABORT("Laguna: unexpected attention gate width %lld at layer %d "
                        "(expected %lld per-head or %lld per-element)",

--- a/tests/test-llama-archs.cpp
+++ b/tests/test-llama-archs.cpp
@@ -213,6 +213,9 @@ static gguf_context_ptr get_gguf_ctx(const llm_arch arch, const bool moe) {
         ms.add_kv(LLM_KV_EXPERT_GATING_FUNC,         uint32_t(2)); // sigmoid
         ms.add_kv(LLM_KV_EXPERT_GROUP_SCALE,         1.0f);
         ms.add_kv(LLM_KV_EXPERTS_PER_GROUP,          uint32_t(1));
+        ms.add_kv(LLM_KV_EXPERT_SHARED_FEED_FORWARD_LENGTH, n_ff);
+        ms.add_kv(LLM_KV_EXPERT_WEIGHTS_SCALE,       1.0f);
+        ms.add_kv(LLM_KV_EXPERT_WEIGHTS_NORM,        false);
     }
 
     ms.add_kv(LLM_KV_POSNET_EMBEDDING_LENGTH,   n_embd);
@@ -343,6 +346,7 @@ static bool moe_mandatory(const llm_arch arch) {
         case LLM_ARCH_BAILINGMOE2:
         case LLM_ARCH_DOTS1:
         case LLM_ARCH_AFMOE:
+        case LLM_ARCH_LAGUNA:
         case LLM_ARCH_ERNIE4_5:
         case LLM_ARCH_ERNIE4_5_MOE:
         case LLM_ARCH_HUNYUAN_MOE:

--- a/tools/quantize/quantize.cpp
+++ b/tools/quantize/quantize.cpp
@@ -37,6 +37,7 @@ static const std::vector<quant_option> QUANT_OPTIONS = {
     { "Q4_0",     LLAMA_FTYPE_MOSTLY_Q4_0,     " 4.34G, +0.4685 ppl @ Llama-3-8B",  },
     { "Q4_1",     LLAMA_FTYPE_MOSTLY_Q4_1,     " 4.78G, +0.4511 ppl @ Llama-3-8B",  },
     { "MXFP4_MOE",LLAMA_FTYPE_MOSTLY_MXFP4_MOE," MXFP4 MoE",  },
+    { "NVFP4",    LLAMA_FTYPE_MOSTLY_NVFP4,    " 4.50 bpw NVIDIA FP4",  },
     { "Q5_0",     LLAMA_FTYPE_MOSTLY_Q5_0,     " 5.21G, +0.1316 ppl @ Llama-3-8B",  },
     { "Q5_1",     LLAMA_FTYPE_MOSTLY_Q5_1,     " 5.65G, +0.1062 ppl @ Llama-3-8B",  },
     { "IQ2_XXS",  LLAMA_FTYPE_MOSTLY_IQ2_XXS,  " 2.06 bpw quantization",            },


### PR DESCRIPTION
Promotion of the stabilized dev branch to master. Contents since `b75801d55`:

## Fixes
- **test-llama-archs / laguna** (#38): laguna is MoE-only; fixture now writes the three required expert keys; gate-width detection falls back to per-head when tensor metadata is unavailable; `llama_model_saver` wrote `n_ff_chexp` under the shared-expert key, zeroing `n_ff_shexp` on save/reload roundtrip — fixed. Un-reds `ubuntu-llvmpipe` / `CI (cpu)` on master.
- **CI triggers** (#38): required status checks now always report on PRs (paths filters dropped from `pull_request` triggers) — no more PRs stuck in "Expected".

## Features
- **NVFP4 as a quantization target** (#39): `llama-quantize model-f16.gguf out.gguf NVFP4`; `llama-quantize` now ships in linux/macos archives (windows already had it).
- **linux-x64-cuda-13.3 build** (#40): first Linux CUDA artifact — dlopen'd `libggml-cuda.so` next to the CPU variants, cudart/cublas bundled, archs 80/86/89/90/120 (A100 / RTX 30 / RTX 40 / H100+H200 / RTX 50).
- **GPU smoke CI** (#41, #42): `backend-smoke.yml` — on-demand + nightly smoke of released archives on rented vast.ai GPUs; asserts coherent NVFP4 generation AND that the GPU backend actually did the work. Posts non-required `gpu-smoke/<backend>` commit statuses. The *Run workflow* button becomes available once this PR lands on master.

## Verified on a rented RTX 5090 (dev-latest, f2757dfb0)
| backend | pp512 | tg128 |
|---|---|---|
| linux-x64-vulkan | 25.4k t/s | 674 t/s |
| linux-x64-cuda-13.3 | **60.5k t/s** | **1349 t/s** |

Both legs: NVFP4 quantize with the shipped tool, coherent generation, GPU-actually-used assert green (after #42).

Release `b10018-1.0.1` will be cut from master after this merge.