### PR TITLE
perf(ci): cut CUDA build time and archive size

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -108,7 +108,7 @@ jobs:
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-vulkan.zip .
+          zip -ry ../llama-turboquant-linux-x64-vulkan.zip .
           tar -czf ../llama-turboquant-linux-x64-vulkan.tar.gz .
 
       - name: Upload archive
@@ -147,9 +147,10 @@ jobs:
 
       - name: Build
         # Consumer SASS: RTX 30 (86), RTX 40 (89), RTX 50 / Blackwell (120).
-        # PTX floor at Turing (75-virtual) so Turing/older consumer and all
-        # server cards (A100 80, H100/H200 90, B200 100) JIT at first run --
-        # we don't ship their SASS, which is what bloated the archive. Runner
+        # Two PTX floors: 75-virtual for Turing, 80-virtual so the server cards
+        # (A100 80, H100 90, B200 100) JIT Ampere-class code instead of Turing
+        # code -- cp.async and the Ampere MMA path are gated on __CUDA_ARCH__
+        # >= 800, so a compute_75 PTX fallback quietly cost them both. Runner
         # has no GPU: build only, backend is a dlopen'd libggml-cuda.so.
         run: |
           cmake -B build \
@@ -161,7 +162,8 @@ jobs:
             -DGGML_CPU_ALL_VARIANTS=ON \
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
-            -DCMAKE_CUDA_ARCHITECTURES="75-virtual;86-real;89-real;120-real" \
+            -DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;120-real" \
+            -DCMAKE_CUDA_FLAGS=-compress-mode=size \
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DLLAMA_CURL=OFF \
             -DLLAMA_OPENSSL=OFF \
@@ -192,7 +194,7 @@ jobs:
           cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-cuda-13.3.zip .
+          zip -ry ../llama-turboquant-linux-x64-cuda-13.3.zip .
           tar -czf ../llama-turboquant-linux-x64-cuda-13.3.tar.gz .
 
       - name: Upload archive
@@ -262,6 +264,7 @@ jobs:
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
             -DCMAKE_CUDA_ARCHITECTURES="90-virtual;121-real" \
+            -DCMAKE_CUDA_FLAGS=-compress-mode=size \
             -DCMAKE_CUDA_HOST_COMPILER=g++-14 \
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DLLAMA_CURL=OFF \
@@ -298,7 +301,7 @@ jobs:
           cp -P "$CUDA_LIB"/libcublasLt.so* release/build/bin/
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-arm64-cuda-13.3.zip .
+          zip -ry ../llama-turboquant-linux-arm64-cuda-13.3.zip .
           tar -czf ../llama-turboquant-linux-arm64-cuda-13.3.tar.gz .
 
       - name: Upload archive
@@ -365,7 +368,7 @@ jobs:
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-cpu.zip .
+          zip -ry ../llama-turboquant-linux-x64-cpu.zip .
           tar -czf ../llama-turboquant-linux-x64-cpu.tar.gz .
 
       - name: Upload archive
@@ -447,7 +450,7 @@ jobs:
           cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-cuda-12.4.zip .
+          zip -ry ../llama-turboquant-linux-x64-cuda-12.4.zip .
           tar -czf ../llama-turboquant-linux-x64-cuda-12.4.tar.gz .
 
       - name: Upload archive
@@ -561,7 +564,7 @@ jobs:
           MI200/MI300). Older GCN GPUs: use the Vulkan build.
           EOF
           cd release
-          zip -r ../llama-turboquant-linux-x64-rocm.zip .
+          zip -ry ../llama-turboquant-linux-x64-rocm.zip .
           tar -czf ../llama-turboquant-linux-x64-rocm.tar.gz .
 
       - name: Upload archive
@@ -584,12 +587,21 @@ jobs:
             cmake_flags: ''
           - variant: vulkan
             cmake_flags: '-DGGML_VULKAN=ON'
+          # Arch lists are pinned instead of falling back to the ggml default,
+          # which builds 8 targets for 12.4 and 7 for 13.3. Nothing that runs
+          # today stops running: the only targets dropped are 90-virtual on
+          # 12.4 (Hopper on a 12.4-era driver is not a Windows scenario, and it
+          # still JITs from 80-virtual) and 121a-real on 13.3 (GB10 is the
+          # arm64 Linux archive's job).
           - variant: cuda-12.4
             cuda: '12.4'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="50-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-real;89-real"'
+          # -compress-mode=size shrinks the fatbin at no cost to kernel speed
+          # (decompression happens once, at module load). Needs CTK >= 12.8, so
+          # the 12.4 variant cannot have it.
           - variant: cuda-13.3
             cuda: '13.3'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;90-virtual;120a-real" -DCMAKE_CUDA_FLAGS=-compress-mode=size'
 
     steps:
       - name: Clone
@@ -601,7 +613,10 @@ jobs:
         uses: ggml-org/ccache-action@v1.2.21
         with:
           key: turboquant-windows-x64-${{ matrix.variant }}
-          evict-old-files: 1d
+          # 500M (the action default) cannot hold a CUDA build, so the cache
+          # thrashed and every run was effectively cold.
+          max-size: ${{ startsWith(matrix.variant, 'cuda') && '2G' || '500M' }}
+          evict-old-files: 7d
 
       - name: Install CUDA Toolkit
         if: ${{ startsWith(matrix.variant, 'cuda') }}
@@ -621,6 +636,18 @@ jobs:
       - name: Install Ninja
         run: choco install ninja -y
 
+      # Defender scans every object nvcc writes, and the CUDA variants write
+      # tens of thousands of them. Best-effort: never fail the build over it.
+      - name: Exclude build tree from Defender
+        shell: pwsh
+        run: |
+          try {
+            Add-MpPreference -ExclusionPath "${{ github.workspace }}", "$env:RUNNER_TEMP"
+            Add-MpPreference -ExclusionProcess "nvcc.exe", "cl.exe", "ninja.exe", "cicc.exe", "ptxas.exe", "cudafe++.exe"
+          } catch {
+            Write-Host "Defender exclusions unavailable: $_"
+          }
+
       - name: Build
         shell: cmd
         # NOTE: GGML_CUDA_CUB_3DOT2 can be dropped once CCCL 3.2 ships in the CTK used here.
@@ -638,7 +665,7 @@ jobs:
             -DLLAMA_BUILD_TESTS=OFF ^
             -DLLAMA_BUILD_EXAMPLES=OFF ^
             ${{ matrix.cmake_flags }}
-          set /A NINJA_JOBS=%NUMBER_OF_PROCESSORS%-1
+          set NINJA_JOBS=%NUMBER_OF_PROCESSORS%
           cmake --build build --config Release -j %NINJA_JOBS% -t ggml
           cmake --build build --config Release -j %NINJA_JOBS%
 
@@ -678,7 +705,16 @@ jobs:
           New-Item -ItemType Directory -Force -Path release\build\bin | Out-Null
           Copy-Item .\build\bin\Release\* release\build\bin\ -Recurse -Force
           Copy-Item .\LICENSE release\build\bin\ -ErrorAction SilentlyContinue
-          Compress-Archive -Path release\build -DestinationPath llama-turboquant-windows-x64-${{ matrix.variant }}.zip -Force
+          $zip = "llama-turboquant-windows-x64-${{ matrix.variant }}.zip"
+          # Compress-Archive is single-threaded and needs double-digit minutes
+          # on the CUDA archives. 7-Zip ships with the runner image.
+          if (Get-Command 7z -ErrorAction SilentlyContinue) {
+            Push-Location release
+            7z a -tzip -mx=5 -mmt=on "..\$zip" build | Out-Null
+            Pop-Location
+          } else {
+            Compress-Archive -Path release\build -DestinationPath $zip -Force
+          }
 
       - name: Upload archive
         uses: actions/upload-artifact@v4

--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -587,21 +587,13 @@ jobs:
             cmake_flags: ''
           - variant: vulkan
             cmake_flags: '-DGGML_VULKAN=ON'
-          # Arch lists are pinned instead of falling back to the ggml default,
-          # which builds 8 targets for 12.4 and 7 for 13.3. Nothing that runs
-          # today stops running: the only targets dropped are 90-virtual on
-          # 12.4 (Hopper on a 12.4-era driver is not a Windows scenario, and it
-          # still JITs from 80-virtual) and 121a-real on 13.3 (GB10 is the
-          # arm64 Linux archive's job).
+          # Do not add flags here -- see the CUDA_EXTRA note in the Build step.
           - variant: cuda-12.4
             cuda: '12.4'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="50-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-real;89-real"'
-          # -compress-mode=size shrinks the fatbin at no cost to kernel speed
-          # (decompression happens once, at module load). Needs CTK >= 12.8, so
-          # the 12.4 variant cannot have it.
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
           - variant: cuda-13.3
             cuda: '13.3'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;90-virtual;120a-real" -DCMAKE_CUDA_FLAGS=-compress-mode=size'
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
 
     steps:
       - name: Clone
@@ -650,9 +642,21 @@ jobs:
 
       - name: Build
         shell: cmd
+        # CUDA_EXTRA carries the pinned arch lists (the ggml default builds 8
+        # targets on 12.4 and 7 on 13.3, including DGX Spark SASS on Windows)
+        # and -compress-mode=size, which needs CTK >= 12.8 so 12.4 cannot have
+        # it. These live here rather than in the matrix because a matrix value
+        # becomes part of the job's display name, and those names are master's
+        # required status checks -- renaming one leaves the required check
+        # permanently "Expected" and the PR unmergeable.
+        # Nothing that runs today loses support: only 90-virtual on 12.4
+        # (Hopper still JITs from 80-virtual) and 121a-real on 13.3 are dropped.
         # NOTE: GGML_CUDA_CUB_3DOT2 can be dropped once CCCL 3.2 ships in the CTK used here.
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          set CUDA_EXTRA=
+          if "${{ matrix.variant }}"=="cuda-12.4" set CUDA_EXTRA=-DCMAKE_CUDA_ARCHITECTURES="50-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-real;89-real"
+          if "${{ matrix.variant }}"=="cuda-13.3" set CUDA_EXTRA=-DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;90-virtual;120a-real" -DCMAKE_CUDA_FLAGS=-compress-mode=size
           cmake -S . -B build -G "Ninja Multi-Config" ^
             -DGGML_NATIVE=OFF ^
             -DGGML_BACKEND_DL=ON ^
@@ -664,7 +668,7 @@ jobs:
             -DLLAMA_BUILD_TOOLS=ON ^
             -DLLAMA_BUILD_TESTS=OFF ^
             -DLLAMA_BUILD_EXAMPLES=OFF ^
-            ${{ matrix.cmake_flags }}
+            ${{ matrix.cmake_flags }} %CUDA_EXTRA%
           set NINJA_JOBS=%NUMBER_OF_PROCESSORS%
           cmake --build build --config Release -j %NINJA_JOBS% -t ggml
           cmake --build build --config Release -j %NINJA_JOBS%

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -589,21 +589,13 @@ jobs:
             cmake_flags: ''
           - variant: vulkan
             cmake_flags: '-DGGML_VULKAN=ON'
-          # Arch lists are pinned instead of falling back to the ggml default,
-          # which builds 8 targets for 12.4 and 7 for 13.3. Nothing that runs
-          # today stops running: the only targets dropped are 90-virtual on
-          # 12.4 (Hopper on a 12.4-era driver is not a Windows scenario, and it
-          # still JITs from 80-virtual) and 121a-real on 13.3 (GB10 is the
-          # arm64 Linux archive's job).
+          # Do not add flags here -- see the CUDA_EXTRA note in the Build step.
           - variant: cuda-12.4
             cuda: '12.4'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="50-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-real;89-real"'
-          # -compress-mode=size shrinks the fatbin at no cost to kernel speed
-          # (decompression happens once, at module load). Needs CTK >= 12.8, so
-          # the 12.4 variant cannot have it.
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
           - variant: cuda-13.3
             cuda: '13.3'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;90-virtual;120a-real" -DCMAKE_CUDA_FLAGS=-compress-mode=size'
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
 
     steps:
       - name: Clone
@@ -652,8 +644,20 @@ jobs:
 
       - name: Build
         shell: cmd
+        # CUDA_EXTRA carries the pinned arch lists (the ggml default builds 8
+        # targets on 12.4 and 7 on 13.3, including DGX Spark SASS on Windows)
+        # and -compress-mode=size, which needs CTK >= 12.8 so 12.4 cannot have
+        # it. These live here rather than in the matrix because a matrix value
+        # becomes part of the job's display name, and those names are master's
+        # required status checks -- renaming one leaves the required check
+        # permanently "Expected" and the PR unmergeable.
+        # Nothing that runs today loses support: only 90-virtual on 12.4
+        # (Hopper still JITs from 80-virtual) and 121a-real on 13.3 are dropped.
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+          set CUDA_EXTRA=
+          if "${{ matrix.variant }}"=="cuda-12.4" set CUDA_EXTRA=-DCMAKE_CUDA_ARCHITECTURES="50-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-real;89-real"
+          if "${{ matrix.variant }}"=="cuda-13.3" set CUDA_EXTRA=-DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;90-virtual;120a-real" -DCMAKE_CUDA_FLAGS=-compress-mode=size
           cmake -S . -B build -G "Ninja Multi-Config" ^
             -DGGML_NATIVE=OFF ^
             -DGGML_BACKEND_DL=ON ^
@@ -665,7 +669,7 @@ jobs:
             -DLLAMA_BUILD_TOOLS=ON ^
             -DLLAMA_BUILD_TESTS=OFF ^
             -DLLAMA_BUILD_EXAMPLES=OFF ^
-            ${{ matrix.cmake_flags }}
+            ${{ matrix.cmake_flags }} %CUDA_EXTRA%
           set NINJA_JOBS=%NUMBER_OF_PROCESSORS%
           cmake --build build --config Release -j %NINJA_JOBS% -t ggml
           cmake --build build --config Release -j %NINJA_JOBS%

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -110,7 +110,7 @@ jobs:
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-vulkan.zip .
+          zip -ry ../llama-turboquant-linux-x64-vulkan.zip .
           tar -czf ../llama-turboquant-linux-x64-vulkan.tar.gz .
 
       - name: Upload archive
@@ -150,9 +150,10 @@ jobs:
 
       - name: Build
         # Consumer SASS: RTX 30 (86), RTX 40 (89), RTX 50 / Blackwell (120).
-        # PTX floor at Turing (75-virtual) so Turing/older consumer and all
-        # server cards (A100 80, H100/H200 90, B200 100) JIT at first run --
-        # we don't ship their SASS, which is what bloated the archive. Runner
+        # Two PTX floors: 75-virtual for Turing, 80-virtual so the server cards
+        # (A100 80, H100 90, B200 100) JIT Ampere-class code instead of Turing
+        # code -- cp.async and the Ampere MMA path are gated on __CUDA_ARCH__
+        # >= 800, so a compute_75 PTX fallback quietly cost them both. Runner
         # has no GPU: build only, backend is a dlopen'd libggml-cuda.so.
         run: |
           cmake -B build \
@@ -164,7 +165,8 @@ jobs:
             -DGGML_CPU_ALL_VARIANTS=ON \
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
-            -DCMAKE_CUDA_ARCHITECTURES="75-virtual;86-real;89-real;120-real" \
+            -DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;120-real" \
+            -DCMAKE_CUDA_FLAGS=-compress-mode=size \
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DLLAMA_CURL=OFF \
             -DLLAMA_OPENSSL=OFF \
@@ -195,7 +197,7 @@ jobs:
           cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-cuda-13.3.zip .
+          zip -ry ../llama-turboquant-linux-x64-cuda-13.3.zip .
           tar -czf ../llama-turboquant-linux-x64-cuda-13.3.tar.gz .
 
       - name: Upload archive
@@ -266,6 +268,7 @@ jobs:
             -DGGML_CUDA=ON \
             -DGGML_CUDA_CUB_3DOT2=ON \
             -DCMAKE_CUDA_ARCHITECTURES="90-virtual;121-real" \
+            -DCMAKE_CUDA_FLAGS=-compress-mode=size \
             -DCMAKE_CUDA_HOST_COMPILER=g++-14 \
             -DCMAKE_CUDA_COMPILER_LAUNCHER=ccache \
             -DLLAMA_CURL=OFF \
@@ -302,7 +305,7 @@ jobs:
           cp -P "$CUDA_LIB"/libcublasLt.so* release/build/bin/
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-arm64-cuda-13.3.zip .
+          zip -ry ../llama-turboquant-linux-arm64-cuda-13.3.zip .
           tar -czf ../llama-turboquant-linux-arm64-cuda-13.3.tar.gz .
 
       - name: Upload archive
@@ -370,7 +373,7 @@ jobs:
           find build/bin -name "*.so*" -exec cp -P {} release/build/bin/ \; 2>/dev/null || true
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-cpu.zip .
+          zip -ry ../llama-turboquant-linux-x64-cpu.zip .
           tar -czf ../llama-turboquant-linux-x64-cpu.tar.gz .
 
       - name: Upload archive
@@ -453,7 +456,7 @@ jobs:
           cp -P /usr/local/cuda/lib64/libcublasLt.so* release/build/bin/
           cp LICENSE release/build/bin/ 2>/dev/null || true
           cd release
-          zip -r ../llama-turboquant-linux-x64-cuda-12.4.zip .
+          zip -ry ../llama-turboquant-linux-x64-cuda-12.4.zip .
           tar -czf ../llama-turboquant-linux-x64-cuda-12.4.tar.gz .
 
       - name: Upload archive
@@ -562,7 +565,7 @@ jobs:
           MI200/MI300). Older GCN GPUs: use the Vulkan build.
           EOF
           cd release
-          zip -r ../llama-turboquant-linux-x64-rocm.zip .
+          zip -ry ../llama-turboquant-linux-x64-rocm.zip .
           tar -czf ../llama-turboquant-linux-x64-rocm.tar.gz .
 
       - name: Upload archive
@@ -586,12 +589,21 @@ jobs:
             cmake_flags: ''
           - variant: vulkan
             cmake_flags: '-DGGML_VULKAN=ON'
+          # Arch lists are pinned instead of falling back to the ggml default,
+          # which builds 8 targets for 12.4 and 7 for 13.3. Nothing that runs
+          # today stops running: the only targets dropped are 90-virtual on
+          # 12.4 (Hopper on a 12.4-era driver is not a Windows scenario, and it
+          # still JITs from 80-virtual) and 121a-real on 13.3 (GB10 is the
+          # arm64 Linux archive's job).
           - variant: cuda-12.4
             cuda: '12.4'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="50-virtual;61-virtual;70-virtual;75-virtual;80-virtual;86-real;89-real"'
+          # -compress-mode=size shrinks the fatbin at no cost to kernel speed
+          # (decompression happens once, at module load). Needs CTK >= 12.8, so
+          # the 12.4 variant cannot have it.
           - variant: cuda-13.3
             cuda: '13.3'
-            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON'
+            cmake_flags: '-DGGML_CUDA=ON -DGGML_CUDA_CUB_3DOT2=ON -DCMAKE_CUDA_ARCHITECTURES="75-virtual;80-virtual;86-real;89-real;90-virtual;120a-real" -DCMAKE_CUDA_FLAGS=-compress-mode=size'
 
     steps:
       - name: Clone
@@ -603,7 +615,10 @@ jobs:
         uses: ggml-org/ccache-action@v1.2.21
         with:
           key: turboquant-windows-x64-${{ matrix.variant }}
-          evict-old-files: 1d
+          # 500M (the action default) cannot hold a CUDA build, so the cache
+          # thrashed and every run was effectively cold.
+          max-size: ${{ startsWith(matrix.variant, 'cuda') && '2G' || '500M' }}
+          evict-old-files: 7d
 
       - name: Install CUDA Toolkit
         if: ${{ startsWith(matrix.variant, 'cuda') }}
@@ -623,6 +638,18 @@ jobs:
       - name: Install Ninja
         run: choco install ninja -y
 
+      # Defender scans every object nvcc writes, and the CUDA variants write
+      # tens of thousands of them. Best-effort: never fail the build over it.
+      - name: Exclude build tree from Defender
+        shell: pwsh
+        run: |
+          try {
+            Add-MpPreference -ExclusionPath "${{ github.workspace }}", "$env:RUNNER_TEMP"
+            Add-MpPreference -ExclusionProcess "nvcc.exe", "cl.exe", "ninja.exe", "cicc.exe", "ptxas.exe", "cudafe++.exe"
+          } catch {
+            Write-Host "Defender exclusions unavailable: $_"
+          }
+
       - name: Build
         shell: cmd
         run: |
@@ -639,7 +666,7 @@ jobs:
             -DLLAMA_BUILD_TESTS=OFF ^
             -DLLAMA_BUILD_EXAMPLES=OFF ^
             ${{ matrix.cmake_flags }}
-          set /A NINJA_JOBS=%NUMBER_OF_PROCESSORS%-1
+          set NINJA_JOBS=%NUMBER_OF_PROCESSORS%
           cmake --build build --config Release -j %NINJA_JOBS% -t ggml
           cmake --build build --config Release -j %NINJA_JOBS%
 
@@ -675,7 +702,16 @@ jobs:
           New-Item -ItemType Directory -Force -Path release\build\bin | Out-Null
           Copy-Item .\build\bin\Release\* release\build\bin\ -Recurse -Force
           Copy-Item .\LICENSE release\build\bin\ -ErrorAction SilentlyContinue
-          Compress-Archive -Path release\build -DestinationPath llama-turboquant-windows-x64-${{ matrix.variant }}.zip -Force
+          $zip = "llama-turboquant-windows-x64-${{ matrix.variant }}.zip"
+          # Compress-Archive is single-threaded and needs double-digit minutes
+          # on the CUDA archives. 7-Zip ships with the runner image.
+          if (Get-Command 7z -ErrorAction SilentlyContinue) {
+            Push-Location release
+            7z a -tzip -mx=5 -mmt=on "..\$zip" build | Out-Null
+            Pop-Location
+          } else {
+            Compress-Archive -Path release\build -DestinationPath $zip -Force
+          }
 
       - name: Upload archive
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Follow-up to #64 (this is the second commit of that branch, which landed after the merge).

Numbers from release run `30937369755`: windows cuda-12.4 **166 min**, cuda-13.3 **139 min**, and a linux CUDA `.zip` of **1339 MB** against a **548 MB** `.tar.gz` of identical content.

### Time
- Windows never pinned `CMAKE_CUDA_ARCHITECTURES` → ggml default: 8 targets on 12.4, 7 on 13.3 (including `121a-real`, i.e. DGX Spark SASS, on Windows). CUDA compile alone was 95 of the 139 minutes across 124 TUs. Both lists pinned; **no architecture that runs today loses support** — only `90-virtual` on 12.4 (Hopper still JITs from `80-virtual`) and `121a-real` on 13.3 are dropped.
- `set /A NINJA_JOBS=%NUMBER_OF_PROCESSORS%-1` idled one of four cores.
- ccache ran at the action's 500M default — a CUDA build blows through it, so the cache thrashed and every run was cold. 2G for CUDA variants, eviction 1d → 7d.
- Defender scanned every object nvcc emitted; build tree + toolchain processes excluded (best-effort, never fails the job).
- `Compress-Archive` is single-threaded; 7-Zip from the runner image replaces it.

### Size
- `zip -r` follows symlinks, so `libcublas.so` → `.so.13` → `.so.13.5.1.27` was stored three times. `zip -ry` stores the links.
- `-compress-mode=size` on CUDA 13.3 builds. Kernel SASS unchanged; the fatbin decompresses once at module load, not per launch. Upstream enables this by default — this fork disabled it in `02f9af612` as a local GCC 12 workaround, so it is passed from CI instead of flipping the CMake gate back on. Needs CTK ≥ 12.8, so 12.4 keeps the default.

### Bonus fix
Adds `80-virtual` to the linux x64 13.3 list. `CP_ASYNC_AVAILABLE` and `AMPERE_MMA_AVAILABLE` are gated on `__CUDA_ARCH__ >= 800` (`common.cuh:282-292`), so A100/H100/B200 were silently JITing Turing-class kernels from the `compute_75` fallback — same class of gap as the RDNA/CDNA one, but silent: it ran, just slowly.