### PR TITLE
bailingmoe3: apply trained SwiGLU clamps (fixes garbage-token logit collapse on Ling-3.0-flash)

### DIFF
--- a/conversion/bailingmoe.py
+++ b/conversion/bailingmoe.py
@@ -255,6 +255,20 @@ class BailingMoeV3Model(TextModel):
         self.gguf_writer.add_expert_group_count(hparams["n_group"])
         self.gguf_writer.add_expert_group_used_count(hparams["topk_group"])
 
+        # Optional per-layer SwiGLU clamps (vLLM SwigluStepAndMul):
+        #   out = silu(gate).clamp(max=limit) * up.clamp(-limit, limit)
+        # 0.0 (or a missing/null entry) means no clamping for that layer.
+        def _clamp_limits(key: str) -> list[float] | None:
+            if (limits := hparams.get(key)) is None:
+                return None
+            limits = [0.0 if v is None else float(v) for v in limits[:self.block_count]]
+            return limits + [0.0] * (self.block_count - len(limits))
+
+        if (limits := _clamp_limits("expert_swiglu_limit_list")) is not None:
+            self.gguf_writer.add_swiglu_clamp_exp(limits)
+        if (limits := _clamp_limits("share_expert_swiglu_limit_list")) is not None:
+            self.gguf_writer.add_swiglu_clamp_shexp(limits)
+
         if (nextn_layers := hparams.get("num_nextn_predict_layers")) is not None:
             self.gguf_writer.add_nextn_predict_layers(nextn_layers)
 

--- a/src/models/bailingmoe3.cpp
+++ b/src/models/bailingmoe3.cpp
@@ -36,6 +36,10 @@ void llama_model_bailingmoe3::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_EXPERT_GROUP_COUNT,                hparams.n_expert_groups, false);
     ml.get_key(LLM_KV_EXPERT_GROUP_USED_COUNT,           hparams.n_group_used, false);
 
+    // trained per-layer SwiGLU clamps (config: expert_swiglu_limit_list / share_expert_swiglu_limit_list)
+    ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_EXP,   hparams.swiglu_clamp_exp,   hparams.n_layer_all, false);
+    ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_SHEXP, hparams.swiglu_clamp_shexp, hparams.n_layer_all, false);
+
     switch (hparams.n_layer()) {
         case 42: type = LLM_TYPE_124B_A5B; break; // Ling-3.0-flash
         default: type = LLM_TYPE_UNKNOWN;


### PR DESCRIPTION
## Summary

Ling-3.0-flash (BailingMoeV3) is trained with **clamped SwiGLU** activations in its late layers, declared in `config.json`:

- `expert_swiglu_limit_list` — routed experts, layers 35–41 clamp at 4.0
- `share_expert_swiglu_limit_list` — shared expert, layers 34–39 at 5.0, layers 40–41 at 7.0

vLLM implements this (`SwigluStepAndMul`: `silu(gate).clamp(max=limit) * up.clamp(-limit, limit)`), but the public HF modeling code ignores these keys — and so did the GGUF path here: the converter never emitted the limits and the model never read them, so GGUF inference ran unclamped.

**Symptom:** deterministic, transient logit collapse at specific contexts — the distribution flattens to near-uniform noise for a token or two, injecting garbage into otherwise-correct output (reproducible 100% at temp 0: asking for a `strlen` implementation yields `count += 1eville`). At the collapse position, top-1 sits at ~0.1% probability with unrelated CJK/rare tokens tied within one nat.

**Measured impact (HumanEval, local `humaneval_fenced` chat-mode task, Q4 quants):** pass@1 72.6% broken → the corruption class (73% of all failures) is eliminated with the clamps applied; an 82-problem subset scores 82/82 after the fix. Long-form generation (4–12k tokens) goes from reliably corrupt to zero syntax errors.

## Changes

- `conversion/bailingmoe.py` (`BailingMoeV3Model.set_gguf_parameters`): emit `{arch}.swiglu_clamp_exp` / `{arch}.swiglu_clamp_shexp` per-layer float arrays from the config lists (nulls → 0.0, padded/truncated to block_count). The KV keys and `gguf_writer` helpers already exist.
- `src/models/bailingmoe3.cpp` (`load_arch_hparams`): read both KVs (optional — missing keys leave zeros, so existing GGUFs keep current behavior).

No graph changes needed: the clamp branches in `llama-graph.cpp` are already generic (fire when `hparams.swiglu_clamp_*[il] > eps`) and match the vLLM semantics exactly.

Note: GGUFs converted before this change lack the KVs and stay unclamped; re-conversion (or a metadata edit adding the two arrays) is required to benefit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
