### PR TITLE
bailingmoe3: merge to master + trained SwiGLU clamps

### DIFF
--- a/conversion/bailingmoe.py
+++ b/conversion/bailingmoe.py
@@ -255,6 +255,20 @@ class BailingMoeV3Model(TextModel):
         self.gguf_writer.add_expert_group_count(hparams["n_group"])
         self.gguf_writer.add_expert_group_used_count(hparams["topk_group"])
 
+        # Optional per-layer SwiGLU clamps (vLLM SwigluStepAndMul):
+        #   out = silu(gate).clamp(max=limit) * up.clamp(-limit, limit)
+        # 0.0 (or a missing/null entry) means no clamping for that layer.
+        def _clamp_limits(key: str) -> list[float] | None:
+            if (limits := hparams.get(key)) is None:
+                return None
+            limits = [0.0 if v is None else float(v) for v in limits[:self.block_count]]
+            return limits + [0.0] * (self.block_count - len(limits))
+
+        if (limits := _clamp_limits("expert_swiglu_limit_list")) is not None:
+            self.gguf_writer.add_swiglu_clamp_exp(limits)
+        if (limits := _clamp_limits("share_expert_swiglu_limit_list")) is not None:
+            self.gguf_writer.add_swiglu_clamp_shexp(limits)
+
         if (nextn_layers := hparams.get("num_nextn_predict_layers")) is not None:
             self.gguf_writer.add_nextn_predict_layers(nextn_layers)
 

--- a/src/models/bailingmoe3.cpp
+++ b/src/models/bailingmoe3.cpp
@@ -36,6 +36,10 @@ void llama_model_bailingmoe3::load_arch_hparams(llama_model_loader & ml) {
     ml.get_key(LLM_KV_EXPERT_GROUP_COUNT,                hparams.n_expert_groups, false);
     ml.get_key(LLM_KV_EXPERT_GROUP_USED_COUNT,           hparams.n_group_used, false);
 
+    // trained per-layer SwiGLU clamps (config: expert_swiglu_limit_list / share_expert_swiglu_limit_list)
+    ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_EXP,   hparams.swiglu_clamp_exp,   hparams.n_layer_all, false);
+    ml.get_key_or_arr(LLM_KV_SWIGLU_CLAMP_SHEXP, hparams.swiglu_clamp_shexp, hparams.n_layer_all, false);
+
     switch (hparams.n_layer()) {
         case 42: type = LLM_TYPE_124B_A5B; break; // Ling-3.0-flash
         default: type = LLM_TYPE_UNKNOWN;


### PR DESCRIPTION
## Summary

Merges `feat/bailingmoe3` into `master` and lands the fix for the
garbage-token bug reported against the Ling-3.0-flash quants.

Ling 3.0 is trained with **clamped SwiGLU** in its late layers, declared in
the released `config.json`:

- `expert_swiglu_limit_list` — routed experts, 4.0 on layers 35-41
- `share_expert_swiglu_limit_list` — shared expert, 5.0 on 34-39, 7.0 on 40-41

vLLM applies these (`SwigluStepAndMul`). The public HF modeling code does not,
and every GGUF and MLX port was written from that reference — so all of them
ran unclamped, including ours and upstream PR #26608.

## Symptom

An activation occasionally exceeds what training ever allowed. Through
`down_proj` it enters the residual stream as a very large vector; the final
RMSNorm then scales the real signal to near-nothing, and the logits flatten
to near-uniform. Whichever token wins at that point is arbitrary, so a
foreign word appears in otherwise-correct output — deterministically, at
`--temp 0`, at near-zero-entropy positions.

Reproduced on `AD-IQ2_XS`, `--temp 0 --seed 1`: a stray `ulp` token at
`length++;`, at `</style` and at `</html>`. Adding the two KV arrays to that
file's metadata — tensor data untouched — removes all three.

## Changes

- `conversion/bailingmoe.py` — emit `{arch}.swiglu_clamp_exp` and
  `{arch}.swiglu_clamp_shexp` as per-layer float arrays from the config lists
  (nulls → 0.0, padded/truncated to `block_count`).
- `src/models/bailingmoe3.cpp` — read both keys into hparams, optional.

No graph changes. The clamp branches in `llama-graph.cpp` already exist and
fire on `hparams.swiglu_clamp_*[il] > eps`.

## Review notes

**Index alignment.** Both config lists are length 42, equal to
`num_hidden_layers`. Positions map directly to block indices, no offset.
`n_layer_all` resolves to 42 here (the converter drops the MTP block), so the
array length written matches the length requested.

**Semantics.** `build_moe_ffn` reads `swiglu_clamp_exp[il]`, `build_ffn` reads
`swiglu_clamp_shexp[il]`. For non-DEEPSEEK4/DFLASH arches the clamp is
`clamp(silu(gate), -inf, limit) * clamp(up, -limit, limit)` — the same
asymmetry as vLLM, and the gate is clamped after SiLU rather than before. The
leading dense blocks also go through `build_ffn` and read `shexp[il]`, which
is 0.0 for them, so they are unaffected.

## Measurement

`llama-perplexity --kl-divergence`, teacher-forced on ~1.5 MB of C++ source,
ctx 4096, `AD-IQ2_XS`. Base is the clamped model, candidate is the unclamped
one, so the numbers describe what the missing clamp was costing:

| | |
|---|---|
| Mean PPL(Q)/PPL(base) | 1.008255 |
| Mean KLD | 0.007469 ± 0.000317 |
| Median KLD | 0.000005 |
| 99.0% KLD | 0.012950 |
| 99.9% KLD | 0.874671 |
| Maximum KLD | 13.275028 |
| Same top p | 99.511 % |
| 0.1% Δp | −47.300 % |
| Minimum Δp | −99.992 % |

Median at the noise floor and perplexity moving 0.8 %, with a tail three
orders of magnitude above the body: a rare event with catastrophic
consequences, not a uniform degradation. 0.1 % of positions losing more than
47 points of probability on the correct token predicts roughly four destroyed
tokens per 4k generated; three were observed.

On mean KLD the effect is 15× smaller than this file's own quantization
damage (0.0075 vs 0.111), which is why no aggregate metric caught it and why
a 32-token layer-by-layer parity check against the HF reference could not —
that reference is unclamped too.

## Compatibility

- GGUFs converted before this change have no such keys, hparams stay zero,
  and inference is unchanged. Nothing breaks.
- Older binaries loading newly-converted files ignore the two unknown KV keys
  and run as before.
- To benefit, a published file needs the two arrays added. **Re-quantization
  is not required** — no tensor data changes, a metadata rewrite is enough.

## After merge

- [ ] Cut `b10684-1.6.0` and rebuild the release archives
- [ ] Add the two KV arrays to all 26 published GGUF rungs, BF16 base included
- [ ] Re-measure the KLD ladder against a clamped BF16 base — the published
      table was measured against a base that computed incorrectly
- [ ] Re-collect the imatrix on the clamped BF16 and diff it against the
      current one on layers 34-41; re-quantize only if the difference is
      material
- [ ] Update the model card: the layer-by-layer parity claim needs to state
      what was checked, at what length, and that the reference itself was
      incomplete
- [ ] File an issue against upstream PR #26608 — same gap there

## Not included

The HumanEval figures from the original PR description are left out
deliberately. The 82/82 is a post-hoc subset and there is no before/after
pair on the full 164 problems. If those numbers are wanted publicly, the full
set needs re-running on both builds first.