### PR TITLE
vulkan : fix unclosed brace in turbo type guard (backend never compiled)

### DIFF
--- a/ggml/src/ggml-vulkan/ggml-vulkan.cpp
+++ b/ggml/src/ggml-vulkan/ggml-vulkan.cpp
@@ -17602,7 +17602,8 @@ static bool ggml_backend_vk_device_supports_op(ggml_backend_dev_t dev, const ggm
                 // divisible by 128) and only the f32-source variant is compiled
                 if (op->type == GGML_TYPE_TURBO2_0 || op->type == GGML_TYPE_TURBO3_0 || op->type == GGML_TYPE_TURBO4_0) {
                     if (op->src[0]->ne[0] % 128 != 0 || op->src[0]->type != GGML_TYPE_F32) {
-                    return false;
+                        return false;
+                    }
                 }
                 switch (op->type) {
                     case GGML_TYPE_F32:


### PR DESCRIPTION
## Problem

The Vulkan backend on `feature/turboquant-kv-cache` does not compile. The turbo-type guard added to `ggml_backend_vk_device_supports_op` (around line 17603 of `ggml-vulkan.cpp`) opens a block that is never closed:

```cpp
if (op->type == GGML_TYPE_TURBO2_0 || ... TURBO4_0) {
    if (op->src[0]->ne[0] % 128 != 0 || op->src[0]->type != GGML_TYPE_F32) {
    return false;
}                     // closes the inner if only
switch (op->type) {   // now nested inside the never-closed turbo guard
```

Every subsequent function definition in the file is parsed as nested, so a `-DGGML_VULKAN=ON` build fails with a wall of:

```
error: a function-definition is not allowed here before '{' token
```

## Fix

Close the guard so it validates the turbo constraint (head_dim divisible by 128, f32 source) and falls through to the existing type switch — which already handles `GGML_TYPE_TURBO{2,3,4}_0` — as clearly intended.

## Verified

Built with `-DGGML_VULKAN=ON -DGGML_NATIVE=ON -DCMAKE_BUILD_TYPE=Release` (0 errors) and served `Qwen3.6-35B-A3B-UD-Q4_K_XL-MTP` on an AMD Radeon AI PRO R9700 (RDNA4/gfx1201, RADV, Mesa 25.2.8) with `-ctk turbo3 -ctv turbo3 --spec-type draft-mtp -c 262144`. Turbo KV, MTP speculation and 256K context all work; measured 139 t/s decode with `-ub 2048`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)