### PR TITLE
ci(windows-rocm): sign the whole HIP payload + 1.6.0 changelog

### DIFF
--- a/.github/workflows/dev-build.yml
+++ b/.github/workflows/dev-build.yml
@@ -844,20 +844,11 @@ jobs:
           }
           $dll | Format-Table FullName, Length -AutoSize
 
-      # Only our own DLL gets our signature; the AMD DLLs stay as AMD ships them.
-      - name: Stage ggml-hip.dll for signing
+      - name: Stage ggml-hip.dll
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path hip-out | Out-Null
           Copy-Item build\bin\Release\ggml-hip.dll hip-out\
-
-      - name: Sign ggml-hip.dll
-        uses: ./.github/actions/windows-code-sign
-        with:
-          path: hip-out
-          sm-api-key: ${{ secrets.SM_API_KEY }}
-          sm-client-cert-b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
-          sm-client-cert-password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
       - name: Bundle ROCm runtime
         shell: pwsh
@@ -903,6 +894,17 @@ jobs:
           }
           $total = (Get-ChildItem -Path hip-out -File | Measure-Object -Property Length -Sum).Sum
           Write-Host ("  HIP backend payload total: {0:N1} MiB" -f ($total / 1MB))
+
+      # Same rule as the CUDA archives: everything in the payload carries a
+      # signature. The action skips files that already have a valid one, so
+      # AMD-signed DLLs keep AMD's signature and unsigned ones get ours.
+      - name: Sign HIP backend
+        uses: ./.github/actions/windows-code-sign
+        with:
+          path: hip-out
+          sm-api-key: ${{ secrets.SM_API_KEY }}
+          sm-client-cert-b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+          sm-client-cert-password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
       - name: Upload HIP backend
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release-turboquant.yml
+++ b/.github/workflows/release-turboquant.yml
@@ -854,20 +854,11 @@ jobs:
           }
           $dll | Format-Table FullName, Length -AutoSize
 
-      # Only our own DLL gets our signature; the AMD DLLs stay as AMD ships them.
-      - name: Stage ggml-hip.dll for signing
+      - name: Stage ggml-hip.dll
         shell: pwsh
         run: |
           New-Item -ItemType Directory -Force -Path hip-out | Out-Null
           Copy-Item build\bin\Release\ggml-hip.dll hip-out\
-
-      - name: Sign ggml-hip.dll
-        uses: ./.github/actions/windows-code-sign
-        with:
-          path: hip-out
-          sm-api-key: ${{ secrets.SM_API_KEY }}
-          sm-client-cert-b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
-          sm-client-cert-password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
       - name: Bundle ROCm runtime
         shell: pwsh
@@ -913,6 +904,17 @@ jobs:
           }
           $total = (Get-ChildItem -Path hip-out -File | Measure-Object -Property Length -Sum).Sum
           Write-Host ("  HIP backend payload total: {0:N1} MiB" -f ($total / 1MB))
+
+      # Same rule as the CUDA archives: everything in the payload carries a
+      # signature. The action skips files that already have a valid one, so
+      # AMD-signed DLLs keep AMD's signature and unsigned ones get ours.
+      - name: Sign HIP backend
+        uses: ./.github/actions/windows-code-sign
+        with:
+          path: hip-out
+          sm-api-key: ${{ secrets.SM_API_KEY }}
+          sm-client-cert-b64: ${{ secrets.SM_CLIENT_CERT_FILE_B64 }}
+          sm-client-cert-password: ${{ secrets.SM_CLIENT_CERT_PASSWORD }}
 
       - name: Upload HIP backend
         uses: actions/upload-artifact@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,39 @@ commit list underneath.
 
 Releases before `b10269-1.5.0` predate this file; see the git history.
 
+## b10269-1.6.0
+
+### Added
+
+- **Windows AMD ROCm archive** `llama-turboquant-windows-x64-rocm.zip`. HIP
+  backend for RDNA2 through RDNA4 and Ryzen AI 300 / Ryzen AI Max (gfx1030,
+  gfx1100/1101/1102/1103, gfx1150/1151, gfx1200/1201), self-contained: the HIP
+  runtime and the BLAS DLLs it links are bundled (about 100 MB), only a current
+  Adrenalin driver is needed, no ROCm SDK install. Until now Windows + Radeon
+  meant the Vulkan build; HIP is the faster prompt-processing path on these
+  GPUs. Everything in the archive is Authenticode-signed, the AMD DLLs with
+  AMD's signature where they ship one.
+- **Linux ROCm archive** now also targets gfx950 (Instinct MI350/MI355X),
+  gfx1150 (Ryzen AI 300) and gfx1103 (Radeon 780M/760M).
+- `docs/amd/`: what ships for AMD, the ROCm vs Vulkan benchmark plan for the
+  TurboQuant KV cache, and the open items. `scripts/bench-amd.sh` runs that
+  matrix per backend build, `scripts/bench-amd-report.py` renders one table.
+
+### Changed
+
+- ROCm builds no longer pass `GGML_HIP_ROCWMMA_FATTN`; upstream removed the
+  rocWMMA flash-attention path and the flag was a no-op.
+
+### Notes
+
+- **The Windows ROCm archive is beta.** It is built, signed and checked for
+  completeness in CI, but has not been run on a Radeon yet. `llama-server
+  --list-devices` must show a HIP device; if it does not, or if loading fails,
+  report the GPU, driver version and the error, and use the Vulkan archive in
+  the meantime.
+- Atomic Chat does not select the Windows ROCm backend yet; the client change
+  follows separately. Until then it is a manual download.
+
 ## b10269-1.5.1
 
 ### Fixed


### PR DESCRIPTION
- Sign the HIP payload after bundling (ggml-hip.dll plus the ROCm DLLs), same rule as the CUDA archives: the code-sign action skips files that already carry a valid signature.
- CHANGELOG section for b10269-1.6.0 so verify-version lets the release through.

🤖 Generated with [Claude Code](https://claude.com/claude-code)